### PR TITLE
fix: 초기 설정 오류 수정

### DIFF
--- a/src/main/java/com/lovecloud/global/exception/LoveCloudException.java
+++ b/src/main/java/com/lovecloud/global/exception/LoveCloudException.java
@@ -1,5 +1,8 @@
 package com.lovecloud.global.exception;
 
+import static com.lovecloud.global.exception.ErrorCode.INTERNAL_SERVER_ERROR_CODE;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 import lombok.Getter;
 
 @Getter
@@ -14,7 +17,10 @@ public class LoveCloudException extends RuntimeException {
 
     public LoveCloudException(String message) {
         super(message);
-        this.errorCode = new Err;
+        this.errorCode = new ErrorCode(INTERNAL_SERVER_ERROR, message);
     }
 
+    public LoveCloudException() {
+        this.errorCode = INTERNAL_SERVER_ERROR_CODE;
+    }
 }

--- a/src/main/java/com/lovecloud/usermanagement/domain/User.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/User.java
@@ -38,8 +38,7 @@ public abstract class User extends CommonRootEntity<Long> {
     @Column(name = "user_role", nullable = false, length = 100)
     private UserRole userRole;
 
-    @Builder
-    public User(String email, String name, UserRole userRole) {
+    protected User(String email, String name, UserRole userRole) {
         this.email = email;
         this.name = name;
         this.userRole = userRole;

--- a/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
+++ b/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
@@ -1,6 +1,7 @@
 package com.lovecloud.usermanagement.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,5 +25,34 @@ class UserTest {
         assertEquals(UserRole.GUEST, guest.getUserRole());
         assertEquals("010-1234-5678", guest.getPhoneNumber());
         assertEquals("password", guest.getPassword());
+    }
+
+    @Test
+    @DisplayName("웨딩 유저 생성 테스트")
+    void createWeddingUserTest() {
+        WeddingUser weddingUser = WeddingUser.builder()
+                .email("wedding@example.com")
+                .name("wedding")
+                .userRole(UserRole.WEDDING_USER)
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .accountStatus(AccountStatus.ACTIVE)
+                .weddingRole(WeddingRole.BRIDE)
+                .oauthId("oauthId")
+                .oauth("oauth")
+                .invitationCode("invitationCode")
+                .build();
+
+        assertNotNull(weddingUser);
+        assertEquals("wedding@example.com", weddingUser.getEmail());
+        assertEquals("wedding", weddingUser.getName());
+        assertEquals(UserRole.WEDDING_USER, weddingUser.getUserRole());
+        assertEquals("010-1234-5678", weddingUser.getPhoneNumber());
+        assertEquals("password", weddingUser.getPassword());
+        assertEquals(AccountStatus.ACTIVE, weddingUser.getAccountStatus());
+        assertEquals(WeddingRole.BRIDE, weddingUser.getWeddingRole());
+        assertEquals("oauthId", weddingUser.getOauthId());
+        assertEquals("oauth", weddingUser.getOauth());
+        assertEquals("invitationCode", weddingUser.getInvitationCode());
     }
 }

--- a/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
+++ b/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
@@ -1,0 +1,28 @@
+package com.lovecloud.usermanagement.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    @Test
+    @DisplayName("게스트 생성 테스트")
+    void createGuestTest() {
+        Guest guest = Guest.builder()
+                .email("guest@example.com")
+                .name("guest")
+                .userRole(UserRole.GUEST)
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .build();
+
+        assertNotNull(guest);
+        assertEquals("guest@example.com", guest.getEmail());
+        assertEquals("guest", guest.getName());
+        assertEquals(UserRole.GUEST, guest.getUserRole());
+        assertEquals("010-1234-5678", guest.getPhoneNumber());
+        assertEquals("password", guest.getPassword());
+    }
+}

--- a/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
+++ b/src/test/java/com/lovecloud/usermanagement/domain/UserTest.java
@@ -55,4 +55,21 @@ class UserTest {
         assertEquals("oauth", weddingUser.getOauth());
         assertEquals("invitationCode", weddingUser.getInvitationCode());
     }
+
+    @Test
+    @DisplayName("관리자 생성 테스트")
+    void createAdminTest() {
+        Admin admin = Admin.builder()
+                .email("admin@example.com")
+                .name("admin")
+                .userRole(UserRole.ADMIN)
+                .password("password")
+                .build();
+
+        assertNotNull(admin);
+        assertEquals("admin@example.com", admin.getEmail());
+        assertEquals("admin", admin.getName());
+        assertEquals(UserRole.ADMIN, admin.getUserRole());
+        assertEquals("password", admin.getPassword());
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #8 

## 💗 작업 동기

LoveCloudException 클래스와 User 추상 클래스에서 발견된 문제를 수정하고, User 추상 클래스를 상속 받는 Guest, WeddingUser, Admin 클래스에 대한 객체 생성 테스트를 진행하였습니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/f40273bb-2b91-4bd0-a38c-f3b23db8de8c)
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/e50e9c96-b08f-4b32-8958-1158b5f632d9)

## 🛠️ 작업 내용
- [x] LoveCloudException 클래스 내 미완성 코드 추가 작성
- [x] User 추상 클래스에서 @Builder 어노테이션을 제거하고, 생성자의 접근 제어자를 protected로 변경
- [x] Guest, WeddingUser, Admin 클래스에 대한 객체 생성 테스트 코드 작성

## 🎯 리뷰 포인트

아래 사항을 유념하여 리뷰 부탁드립니다.

- LoveCloudException에 추가된 코드가 적절한지 여부
- User 클래스의 변경사항이 상속구조에 영향을 미치지 않는지

## ✅ 테스트 결과
-  User 추상 클래스를 상속 받는 Guest, WeddingUser, Admin 클래스에 대한 객체 생성 테스트
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/7a0c5dac-8bd2-4c0b-84e2-3862843dc444)
