### PR TITLE
Feat/#9 암호 처리

### DIFF
--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.lovecloud.global.config;
+
+import com.lovecloud.global.crypto.BCryptCustomPasswordEncoder;
+import com.lovecloud.global.crypto.CustomPasswordEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public CustomPasswordEncoder passwordEncoder() {
+        return new BCryptCustomPasswordEncoder();
+    }
+}

--- a/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
@@ -1,15 +1,16 @@
 package com.lovecloud.global.crypto;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BCryptCustomPasswordEncoder implements CustomPasswordEncoder{
 
-    private final BCryptCustomPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
 
 
     public BCryptCustomPasswordEncoder() {
-        this.passwordEncoder = new BCryptCustomPasswordEncoder();
+        this.passwordEncoder = new BCryptPasswordEncoder();
     }
 
     @Override

--- a/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
@@ -1,0 +1,24 @@
+package com.lovecloud.global.crypto;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BCryptCustomPasswordEncoder implements CustomPasswordEncoder{
+
+    private final BCryptCustomPasswordEncoder passwordEncoder;
+
+
+    public BCryptCustomPasswordEncoder() {
+        this.passwordEncoder = new BCryptCustomPasswordEncoder();
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/lovecloud/global/crypto/CustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/CustomPasswordEncoder.java
@@ -1,0 +1,6 @@
+package com.lovecloud.global.crypto;
+
+public interface CustomPasswordEncoder {
+    String encode(CharSequence rawPassword);
+    boolean matches(CharSequence rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
+++ b/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.lovecloud.global.usermanager;
+
+import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JpaUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Optional<User> user = userRepository.findByUsername(username);
+
+        if(user.isPresent()) {
+            return new SecurityUser(user.get());
+        } else {
+            throw new UsernameNotFoundException("User not found");
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
+++ b/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
@@ -1,0 +1,62 @@
+package com.lovecloud.global.usermanager;
+
+import com.lovecloud.usermanagement.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class SecurityUser implements UserDetails {
+
+    private final User user;
+
+    public SecurityUser(User user) {this.user = user;}
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        List<GrantedAuthority> authorities = new ArrayList<>(2);
+        authorities.add(new SimpleGrantedAuthority(user.getUserRole().name()));
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    /*
+    계정의 만료 여부 리턴
+   */
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    /*
+    계정의 잠김 여부 리턴
+    */
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
+++ b/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.lovecloud.usermanagement.repository;
+
+import com.lovecloud.usermanagement.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #9 
closed #15 

## 💗 작업 동기
password 암호화를 위한 처리 구현 

## 🛠️ 작업 내용
- [x] CustomPasswordEncoder 인터페이스 정의
- [x] BCryptCustomPasswordEncoder 구현 
- [x] SecurityConfig 생성 후 PassowrdEncoder @Bean 등록

## 🎯 리뷰 포인트
특정 암호화 구현에 종속되지 않게 추상화를 제공하도록 작성했습니다.
암호화 알고리즘을 변경해야 할 경우 인터페이스의 구현체만 교체하면 됩니다.
현재는 bcrypt 강력 해싱 함수 알고리즘을 사용했습니다.

## ✅ 테스트 결과
