### PR TITLE
Feat/#17 권한 부여 구성

### DIFF
--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -2,15 +2,60 @@ package com.lovecloud.global.config;
 
 import com.lovecloud.global.crypto.BCryptCustomPasswordEncoder;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+//    private static final String[] PUBLIC_ENDPOINTS = {
+//            "/**",
+//    };
+
 
     @Bean
     public CustomPasswordEncoder passwordEncoder() {
         return new BCryptCustomPasswordEncoder();
     }
+
+
+    @Bean
+    WebSecurityCustomizer webSecurityCustomizer() { //정적 리소스 무시
+        return (web) -> web.ignoring().requestMatchers("/swagger-ui/**", "/v3/api-docs/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        configureHttpSecurity(httpSecurity);
+        return httpSecurity.build();
+    }
+
+    private void configureHttpSecurity(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .cors(withDefaults())
+
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+//                        .anyRequest().authenticated());
+
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll());  // 모든 요청을 허용
+
+    }
+
 }

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.lovecloud.global.config;
+
+import com.lovecloud.global.crypto.BCryptCustomPasswordEncoder;
+import com.lovecloud.global.crypto.CustomPasswordEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public CustomPasswordEncoder passwordEncoder() {
+        return new BCryptCustomPasswordEncoder();
+    }
+}

--- a/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
@@ -1,15 +1,16 @@
 package com.lovecloud.global.crypto;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BCryptCustomPasswordEncoder implements CustomPasswordEncoder{
 
-    private final BCryptCustomPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
 
 
     public BCryptCustomPasswordEncoder() {
-        this.passwordEncoder = new BCryptCustomPasswordEncoder();
+        this.passwordEncoder = new BCryptPasswordEncoder();
     }
 
     @Override

--- a/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/BCryptCustomPasswordEncoder.java
@@ -1,0 +1,24 @@
+package com.lovecloud.global.crypto;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BCryptCustomPasswordEncoder implements CustomPasswordEncoder{
+
+    private final BCryptCustomPasswordEncoder passwordEncoder;
+
+
+    public BCryptCustomPasswordEncoder() {
+        this.passwordEncoder = new BCryptCustomPasswordEncoder();
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/lovecloud/global/crypto/CustomPasswordEncoder.java
+++ b/src/main/java/com/lovecloud/global/crypto/CustomPasswordEncoder.java
@@ -1,0 +1,6 @@
+package com.lovecloud.global.crypto;
+
+public interface CustomPasswordEncoder {
+    String encode(CharSequence rawPassword);
+    boolean matches(CharSequence rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
+++ b/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.lovecloud.global.usermanager;
+
+import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JpaUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Optional<User> user = userRepository.findByUsername(username);
+
+        if(user.isPresent()) {
+            return new SecurityUser(user.get());
+        } else {
+            throw new UsernameNotFoundException("User not found");
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
+++ b/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
@@ -16,9 +16,9 @@ public class JpaUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        Optional<User> user = userRepository.findByUsername(username);
+        Optional<User> user = userRepository.findByEmail(email);
 
         if(user.isPresent()) {
             return new SecurityUser(user.get());

--- a/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
+++ b/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
@@ -1,0 +1,62 @@
+package com.lovecloud.global.usermanager;
+
+import com.lovecloud.usermanagement.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class SecurityUser implements UserDetails {
+
+    private final User user;
+
+    public SecurityUser(User user) {this.user = user;}
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        List<GrantedAuthority> authorities = new ArrayList<>(2);
+        authorities.add(new SimpleGrantedAuthority(user.getUserRole().name()));
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    /*
+    계정의 만료 여부 리턴
+   */
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    /*
+    계정의 잠김 여부 리턴
+    */
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
+++ b/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
@@ -31,7 +31,7 @@ public class SecurityUser implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getName();
+        return user.getEmail();
     }
 
     /*

--- a/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
+++ b/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
+++ b/src/main/java/com/lovecloud/usermanagement/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.lovecloud.usermanagement.repository;
+
+import com.lovecloud.usermanagement.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #17 
closed #18 

## 💗 작업 동기
권한 부여 구성 완료

## 🛠️ 작업 내용
- [x] SecurityFilterChain 구성


## 🎯 리뷰 포인트
1. SecurityFilterChain
- Spring Security 5.4 이후 WebSecurityConfigurerAdapter 보다 SecurityFilterChain을 정의하는 방식이 권장됨에 따라 구현하였습니다. (더 유연하고 모듈화 된 구성 제공)

2.  requestMachers
- Spring Security 5.4 이후로 도입된 requestMachers를 사용하였습니다. 기존 mvcMatchers와 antMatchers 보다 더 직관적이고 유연합니다.

3. public Endpoint가 있는데 왜 WebSecurityCustomizer를 사용하는가?
- 정적 리소스 최소화 : Swagger UI와 같은 정적 리소스를 보안 검사를 거치지 않도록 하여 요청 처리 속도를 빠르게 할 수 있습니다.

4. 브랜치 충돌
- 이전 Pull Request의 오류를 현재 브랜치에서 작업하다가 발견했습니다. 따라서 이전 브랜치로 넘어가 수정하고 pr을 다시 올렸는데 그게 현재 브랜치에 적용이 됐는지 모르겠습니다. merge할 때 뭔가 이상하면 말씀해주세요. 되도록 이전 pr부터 merge 시켜주시면 오류 없을것 같습니다.

5. endpoint 
- 개발 편의성을 위해 모든 endpoint를 인증없이 접근가능하도록 주석 처리하고 열어놨습니다. 추후 다른 조치 필요하시면 말씀해주세요

6. csrf 비활성화
- jwt 토큰을 이용한 인증 필터를 구성할 예정이므로 spring security의 기본 csrf 보호를 비활성화 합니다.


## ✅ 테스트 결과
