### PR TITLE
feat: Presigned URL을 이용하여 AWS S3로 이미지 업로드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation platform('software.amazon.awssdk:bom:2.17.53')
+    implementation 'software.amazon.awssdk:s3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/lovecloud/LoveCloudApplication.java
+++ b/src/main/java/com/lovecloud/LoveCloudApplication.java
@@ -2,9 +2,15 @@ package com.lovecloud;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan("com.lovecloud.infra.s3")
 @SpringBootApplication
 public class LoveCloudApplication {
+
+    static {
+        System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(LoveCloudApplication.class, args);

--- a/src/main/java/com/lovecloud/infra/s3/AwsS3Config.java
+++ b/src/main/java/com/lovecloud/infra/s3/AwsS3Config.java
@@ -1,0 +1,43 @@
+package com.lovecloud.infra.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AwsBasicCredentials awsBasicCredentials() {
+        return AwsBasicCredentials.create(accessKey, secretKey);
+    }
+
+    @Bean
+    public S3Client s3Client(AwsBasicCredentials awsBasicCredentials) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner.Builder s3PresignerBuilder(AwsBasicCredentials awsBasicCredentials) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials));
+    }
+}

--- a/src/main/java/com/lovecloud/infra/s3/AwsS3Property.java
+++ b/src/main/java/com/lovecloud/infra/s3/AwsS3Property.java
@@ -1,0 +1,11 @@
+package com.lovecloud.infra.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public record AwsS3Property(
+        String bucket,
+        String imagePath,
+        int presignedUrlExpiresMinutes
+) {
+}

--- a/src/main/java/com/lovecloud/infra/s3/CreatePresignedUrlResponse.java
+++ b/src/main/java/com/lovecloud/infra/s3/CreatePresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.lovecloud.infra.s3;
+
+public record CreatePresignedUrlResponse(
+        String imageName,
+        String presignedUrl
+) {
+}

--- a/src/main/java/com/lovecloud/infra/s3/PresignedUrlService.java
+++ b/src/main/java/com/lovecloud/infra/s3/PresignedUrlService.java
@@ -1,0 +1,52 @@
+package com.lovecloud.infra.s3;
+
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+/**
+ * AWS S3에 파일을 업로드하기 위한 Presigned URL을 생성하는 서비스 클래스이다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PresignedUrlService {
+
+    private final S3Presigner.Builder presignerBuilder;
+    private final AwsS3Property s3Property;
+
+    /**
+     * 이미지 확장자를 기반으로 한 사전 서명된 URL을 생성하고 반환한다.
+     *
+     * @param imageExtension 이미지 파일의 확장자
+     * @return 생성된 이미지 이름과 사전 서명된 URL를 포함하는 {@link CreatePresignedUrlResponse} 객체
+     */
+    public CreatePresignedUrlResponse create(String imageExtension) {
+        String imageName = createImageName(imageExtension);
+        String presignedUrl = createPresignedUrl(imageName);
+        return new CreatePresignedUrlResponse(imageName, presignedUrl);
+    }
+
+    private String createImageName(String imageExtension) {
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + imageExtension;
+    }
+
+    private String createPresignedUrl(String imageName) {
+        try (S3Presigner presigner = presignerBuilder.build()) {
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(s3Property.presignedUrlExpiresMinutes()))
+                    .putObjectRequest(builder -> builder
+                            .bucket(s3Property.bucket())
+                            .key(s3Property.imagePath() + imageName)
+                            .build()
+                    ).build();
+
+            PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
+            return presignedRequest.url().toExternalForm();
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/infra/s3/presentation/CreatePresignedUrlRequest.java
+++ b/src/main/java/com/lovecloud/infra/s3/presentation/CreatePresignedUrlRequest.java
@@ -1,0 +1,11 @@
+package com.lovecloud.infra.s3.presentation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CreatePresignedUrlRequest(
+        @NotBlank
+        @Pattern(regexp = "^(jpeg|jpg|png|gif|bmp)$")
+        String imageExtension
+) {
+}

--- a/src/main/java/com/lovecloud/infra/s3/presentation/PresignedUrlController.java
+++ b/src/main/java/com/lovecloud/infra/s3/presentation/PresignedUrlController.java
@@ -1,0 +1,27 @@
+package com.lovecloud.infra.s3.presentation;
+
+import com.lovecloud.infra.s3.CreatePresignedUrlResponse;
+import com.lovecloud.infra.s3.PresignedUrlService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/storage/presigned-urls")
+public class PresignedUrlController {
+
+    private final PresignedUrlService presignedUrlService;
+
+    @PostMapping
+    public ResponseEntity<CreatePresignedUrlResponse> createPresignedUrl(
+            @Valid @RequestBody CreatePresignedUrlRequest request
+    ) {
+        CreatePresignedUrlResponse response = presignedUrlService.create(request.imageExtension());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,25 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     open-in-view: true
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 logging:
   level:
     org.hibernate.SQL: debug
+
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_BUCKET}
+      image-path: "images/"
+      presigned-url-expires-minutes: 10
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}


### PR DESCRIPTION
## 📌 관련 이슈
closed #7

## 💗 작업 동기
저희 프로젝트에는 상품(대표 이미지, 상세 이미지), 청첩장(대표 이미지)에 이미지 저장 및 관리가 필요합니다. 이를 효율적으로 관리하기 위해 AWS S3를 도입하였고, 서버의 부하를 최소화할 수 있도록 Presigned URL을 사용하였습니다.

## 🛠️ 작업 내용
- [x] build.gradle, application.yml에 AWS 관련 의존성 및 설정 추가
- [x] AwsS3Config에 AWS S3 구성 추가 및 빈 생성
- [x] LoveCloudApplication에 AWS SDK EC2 메타데이터 비활성화 설정 및 프로퍼티 스캔 추가
- [x] CreatePresignedUrlRequest, CreatePresinedUrlResponse, AwsS3Property 구현
- [x] PresignedUrlController, PresignedUrlService에 Presigned URL을 생성하는 로직 구현

## 🎯 리뷰 포인트
전반적인 로직은 아래와 같습니다. 자세한 내용은 오늘 회의 때 설명해드리겠습니다 ^^..

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/4ce7c509-42c6-462d-a993-392bf46dba82)



## ✅ 테스트 결과
1. 먼저 프론트엔트 측에서 이미지 확장자와 함께 presigned url 생성을 요청합니다. 백엔드 측에서 presigned url을 생성 후 presigned url과 image name을 반환합니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/c35fe87d-0c33-4282-af11-f412376e3e44)

2. 프론트 측에서는 반환받은 presigned url로 이미지와 함께 PUT 요청을 보내 이미지를 업로드합니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/3faac16e-a0de-4d26-b61f-8bb7bbc55a8a)

3. 버킷에서 이미지가 업로드된 것을 확인할 수 있습니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/021e89f7-c071-4171-8add-0962bf28ea20)

4. 해당 이미지의 형태는 아래와 같습니다. 즉, 기본 주소/images/{image name} 형태입니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/a836f8c7-ce82-437f-9542-3754175e3781)

5. 해당 주소로 GET 요청을 하면 이미지를 조회할 수 있습니다.

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/f997e544-127d-4eeb-bf47-4eec7afc3500)

## 🔗 관련 링크

- https://aws.amazon.com/ko/blogs/korea/aws-api-call-2-s3-pre-signed-url/
- https://techblog.woowahan.com/11392/
- https://minwoo-it-factory.tistory.com/entry/Presigned-URL%EC%9D%84-%ED%86%B5%ED%95%B4-S3%EC%97%90-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EA%B8%B0
- https://velog.io/@invidam/S3-Presigned-Url-%EB%8F%84%EC%9E%85%ED%95%98%EA%B8%B0