### PR TITLE
feat: 상품 목록/상세 조회 구현

### DIFF
--- a/src/main/java/com/lovecloud/global/config/JpaConfig.java
+++ b/src/main/java/com/lovecloud/global/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.lovecloud.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
@@ -1,0 +1,41 @@
+package com.lovecloud.productmanagement.application;
+
+import com.lovecloud.productmanagement.application.command.CreateProductCommand;
+import com.lovecloud.productmanagement.domain.Category;
+import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
+import com.lovecloud.productmanagement.domain.DescriptionImage;
+import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ProductCreateService {
+
+    private final ProductRepository productRepository;
+    private final CategoryRepository categoryRepository;
+    private final MainImageRepository mainImageRepository;
+    private final DescriptionImageRepository descriptionImageRepository;
+
+    public Long createProduct(CreateProductCommand command) {
+        Category category = categoryRepository.getById(command.categoryId());
+        Product product = command.toProduct(category);
+        product = productRepository.save(product);
+        createAndSaveImages(command, product);
+        return product.getId();
+    }
+
+    private void createAndSaveImages(CreateProductCommand command, Product product) {
+        List<MainImage> mainImages = command.toMainImages(product);
+        mainImageRepository.saveAll(mainImages);
+        List<DescriptionImage> descriptionImages = command.toDescriptionImages(product);
+        descriptionImageRepository.saveAll(descriptionImages);
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
@@ -2,12 +2,12 @@ package com.lovecloud.productmanagement.application;
 
 import com.lovecloud.productmanagement.application.command.CreateProductCommand;
 import com.lovecloud.productmanagement.domain.Category;
-import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
 import com.lovecloud.productmanagement.domain.DescriptionImage;
-import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
 import com.lovecloud.productmanagement.domain.MainImage;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
+import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
+import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
@@ -25,7 +25,7 @@ public class ProductCreateService {
     private final DescriptionImageRepository descriptionImageRepository;
 
     public Long createProduct(CreateProductCommand command) {
-        Category category = categoryRepository.getById(command.categoryId());
+        Category category = categoryRepository.findByIdOrThrow(command.categoryId());
         Product product = command.toProduct(category);
         product = productRepository.save(product);
         createAndSaveImages(command, product);

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductCreateService.java
@@ -9,10 +9,10 @@ import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
 import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreateService.java
@@ -1,0 +1,25 @@
+package com.lovecloud.productmanagement.application;
+
+import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
+import com.lovecloud.productmanagement.domain.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ProductOptionsCreateService {
+
+    private final ProductRepository productRepository;
+    private final ProductOptionsRepository productOptionsRepository;
+
+    public Long addProductOptions(CreateProductOptionsCommand command) {
+        Product product = productRepository.findByIdOrThrow(command.productId());
+        ProductOptions options = command.toProductOptions(product);
+        return productOptionsRepository.save(options).getId();
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreateService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreateService.java
@@ -5,9 +5,9 @@ import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
@@ -1,0 +1,57 @@
+package com.lovecloud.productmanagement.application;
+
+import com.lovecloud.productmanagement.domain.DescriptionImage;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
+import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
+import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
+import com.lovecloud.productmanagement.domain.repository.ProductRepository;
+import com.lovecloud.productmanagement.query.response.ProductResponse;
+import com.lovecloud.productmanagement.query.response.ProductResponseAdapter;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ProductQueryService {
+
+    private final ProductRepository productRepository;
+    private final ProductOptionsRepository productOptionsRepository;
+    private final MainImageRepository mainImageRepository;
+    private final DescriptionImageRepository descriptionImageRepository;
+
+    public List<ProductResponse> findAllByCategoryId(Long categoryId) {
+        List<Product> products = categoryId == null
+                ? productRepository.findAll()
+                : productRepository.findByCategoryId(categoryId);
+        return products.stream()
+                .map(this::mapProductToProductResponse)
+                .collect(Collectors.toList());
+    }
+
+    public ProductResponse findById(Long productId) {
+        Product product = productRepository.findByIdOrThrow(productId);
+        return mapProductToProductResponse(product);
+    }
+
+    private ProductResponse mapProductToProductResponse(Product product) {
+        List<MainImage> mainImages = mainImageRepository.findByProductId(product.getId());
+        List<DescriptionImage> descriptionImages = descriptionImageRepository.findByProductId(
+                product.getId());
+        List<ProductOptions> productOptions = productOptionsRepository.findByProductId(
+                product.getId());
+
+        return ProductResponseAdapter.fromProduct(
+                product,
+                mainImages,
+                descriptionImages,
+                productOptions
+        );
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductCommand.java
@@ -1,0 +1,42 @@
+package com.lovecloud.productmanagement.application.command;
+
+import com.lovecloud.productmanagement.domain.Category;
+import com.lovecloud.productmanagement.domain.DescriptionImage;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.productmanagement.domain.Product;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CreateProductCommand(
+        String productName,
+        Long categoryId,
+        List<String> mainImageNames,
+        List<String> descriptionImageNames
+) {
+
+    public Product toProduct(Category category) {
+        return Product.builder()
+                .productName(productName)
+                .category(category)
+                .build();
+    }
+
+    public List<MainImage> toMainImages(Product product) {
+        return mainImageNames.stream()
+                .map(mainImageName -> MainImage.builder()
+                        .product(product)
+                        .mainImageName(mainImageName)
+                        .build())
+                .toList();
+    }
+
+    public List<DescriptionImage> toDescriptionImages(Product product) {
+        return descriptionImageNames.stream()
+                .map(descriptionImageName -> DescriptionImage.builder()
+                        .product(product)
+                        .descriptionImageName(descriptionImageName)
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
@@ -1,0 +1,25 @@
+package com.lovecloud.productmanagement.application.command;
+
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import lombok.Builder;
+
+@Builder
+public record CreateProductOptionsCommand(
+        Long productId,
+        String color,
+        String modelName,
+        Integer price,
+        Integer stockQuantity
+) {
+
+    public ProductOptions toProductOptions(Product product) {
+        return ProductOptions.builder()
+                .product(product)
+                .color(color)
+                .modelName(modelName)
+                .price(price)
+                .stockQuantity(stockQuantity)
+                .build();
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
@@ -26,16 +26,16 @@ public class DescriptionImage extends CommonRootEntity<Long> {
     @Column(name = "description_image_id")
     private Long id;
 
-    @Column(name = "description_image_url", nullable = false, length = 100)
-    private String descriptionImageUrl;
+    @Column(name = "description_image_name", nullable = false, length = 100)
+    private String descriptionImageName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
     @Builder
-    public DescriptionImage(String descriptionImageUrl, Product product) {
-        this.descriptionImageUrl = descriptionImageUrl;
+    public DescriptionImage(String descriptionImageName, Product product) {
+        this.descriptionImageName = descriptionImageName;
         this.product = product;
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
@@ -26,16 +26,16 @@ public class MainImage extends CommonRootEntity<Long> {
     @Column(name = "main_image_id")
     private Long id;
 
-    @Column(name = "description_image_url", nullable = false, length = 100)
-    private String descriptionImageUrl;
+    @Column(name = "main_image_name", nullable = false, length = 100)
+    private String mainImageName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
     @Builder
-    public MainImage(String descriptionImageUrl, Product product) {
-        this.descriptionImageUrl = descriptionImageUrl;
+    public MainImage(String mainImageName, Product product) {
+        this.mainImageName = mainImageName;
         this.product = product;
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -36,7 +36,7 @@ public class ProductOptions extends CommonRootEntity<Long> {
     private Integer price;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted;
+    private Boolean isDeleted = false;
 
     @Column(name = "stock_quantity", nullable = false)
     private Integer stockQuantity;
@@ -46,12 +46,11 @@ public class ProductOptions extends CommonRootEntity<Long> {
     private Product product;
 
     @Builder
-    public ProductOptions(String color, String modelName, Integer price, Boolean isDeleted,
-            Integer stockQuantity, Product product) {
+    public ProductOptions(String color, String modelName, Integer price, Integer stockQuantity,
+            Product product) {
         this.color = color;
         this.modelName = modelName;
         this.price = price;
-        this.isDeleted = isDeleted;
         this.stockQuantity = stockQuantity;
         this.product = product;
     }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.lovecloud.productmanagement.domain.repository;
+
+import com.lovecloud.productmanagement.domain.Category;
+import com.lovecloud.productmanagement.exception.NotFoundCategoryException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    default Category getById(Long id) {
+        return findById(id).orElseThrow(NotFoundCategoryException::new);
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/CategoryRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    default Category getById(Long id) {
+    default Category findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundCategoryException::new);
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/DescriptionImageRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/DescriptionImageRepository.java
@@ -1,0 +1,8 @@
+package com.lovecloud.productmanagement.domain.repository;
+
+import com.lovecloud.productmanagement.domain.DescriptionImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DescriptionImageRepository extends JpaRepository<DescriptionImage, Long> {
+
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/DescriptionImageRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/DescriptionImageRepository.java
@@ -1,8 +1,12 @@
 package com.lovecloud.productmanagement.domain.repository;
 
 import com.lovecloud.productmanagement.domain.DescriptionImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DescriptionImageRepository extends JpaRepository<DescriptionImage, Long> {
 
+    List<DescriptionImage> findByProductId(Long productId);
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/MainImageRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/MainImageRepository.java
@@ -1,8 +1,12 @@
 package com.lovecloud.productmanagement.domain.repository;
 
 import com.lovecloud.productmanagement.domain.MainImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MainImageRepository extends JpaRepository<MainImage, Long> {
 
+    List<MainImage> findByProductId(Long productId);
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/MainImageRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/MainImageRepository.java
@@ -1,0 +1,8 @@
+package com.lovecloud.productmanagement.domain.repository;
+
+import com.lovecloud.productmanagement.domain.MainImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MainImageRepository extends JpaRepository<MainImage, Long> {
+
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductOptionsRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductOptionsRepository.java
@@ -1,10 +1,12 @@
 package com.lovecloud.productmanagement.domain.repository;
 
 import com.lovecloud.productmanagement.domain.ProductOptions;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductOptionsRepository extends JpaRepository<ProductOptions, Long> {
 
+    List<ProductOptions> findByProductId(Long productId);
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductOptionsRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductOptionsRepository.java
@@ -1,0 +1,10 @@
+package com.lovecloud.productmanagement.domain.repository;
+
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductOptionsRepository extends JpaRepository<ProductOptions, Long> {
+
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
@@ -1,10 +1,14 @@
 package com.lovecloud.productmanagement.domain.repository;
 
 import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.exception.NotFoundProductException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    default Product findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(NotFoundProductException::new);
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.lovecloud.productmanagement.domain.repository;
+
+import com.lovecloud.productmanagement.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/repository/ProductRepository.java
@@ -2,11 +2,14 @@ package com.lovecloud.productmanagement.domain.repository;
 
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.exception.NotFoundProductException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    List<Product> findByCategoryId(Long categoryId);
 
     default Product findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundProductException::new);

--- a/src/main/java/com/lovecloud/productmanagement/exception/NotFoundCategoryException.java
+++ b/src/main/java/com/lovecloud/productmanagement/exception/NotFoundCategoryException.java
@@ -1,0 +1,13 @@
+package com.lovecloud.productmanagement.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+public class NotFoundCategoryException extends LoveCloudException {
+
+    public NotFoundCategoryException() {
+        super(new ErrorCode(NOT_FOUND, "존재하지 않는 카테고리입니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/exception/NotFoundProductException.java
+++ b/src/main/java/com/lovecloud/productmanagement/exception/NotFoundProductException.java
@@ -1,0 +1,13 @@
+package com.lovecloud.productmanagement.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+public class NotFoundProductException extends LoveCloudException {
+
+    public NotFoundProductException() {
+        super(new ErrorCode(NOT_FOUND, "존재하지 않는 상품입니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
@@ -1,0 +1,37 @@
+package com.lovecloud.productmanagement.presentation;
+
+import com.lovecloud.productmanagement.application.ProductCreateService;
+import com.lovecloud.productmanagement.presentation.request.CreateProductRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/products")
+@RestController
+public class ProductController {
+
+    private final ProductCreateService productCreateService;
+
+    @PostMapping
+    public ResponseEntity<Long> creatProduct(
+            @Valid @RequestBody CreateProductRequest request
+    ) {
+        final Long productId = productCreateService.createProduct(request.toCommand());
+        return ResponseEntity.created(URI.create("/products/" + productId)).build();
+    }
+
+/*    @PostMapping("/{productId}/options")
+    public ResponseEntity<Void> addProductOptions(
+            @PathVariable Long productId,
+            @Valid @RequestBody CreateProductOptionRequest request
+    ) {
+        productCreateService.addProductOptions(request.toCommand(productId));
+        return ResponseEntity.created(URI.create("/products/" + productId + "/options")).build();
+    }*/
+}

--- a/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
@@ -2,7 +2,7 @@ package com.lovecloud.productmanagement.presentation;
 
 import com.lovecloud.productmanagement.application.ProductCreateService;
 import com.lovecloud.productmanagement.application.ProductOptionsCreateService;
-import com.lovecloud.productmanagement.presentation.request.CreateProductOptionRequest;
+import com.lovecloud.productmanagement.presentation.request.CreateProductOptionsRequest;
 import com.lovecloud.productmanagement.presentation.request.CreateProductRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -33,7 +33,7 @@ public class ProductController {
     @PostMapping("/{productId}/options")
     public ResponseEntity<Void> addProductOptions(
             @PathVariable Long productId,
-            @Valid @RequestBody CreateProductOptionRequest request
+            @Valid @RequestBody CreateProductOptionsRequest request
     ) {
         final Long optionId = productOptionsCreateService.addProductOptions(request.toCommand(productId));
         return ResponseEntity.created(URI.create("/products/" + productId + "/options/" + optionId)).build();

--- a/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
@@ -35,7 +35,9 @@ public class ProductController {
             @PathVariable Long productId,
             @Valid @RequestBody CreateProductOptionsRequest request
     ) {
-        final Long optionId = productOptionsCreateService.addProductOptions(request.toCommand(productId));
-        return ResponseEntity.created(URI.create("/products/" + productId + "/options/" + optionId)).build();
+        final Long optionId = productOptionsCreateService.addProductOptions(
+                request.toCommand(productId));
+        return ResponseEntity.created(URI.create("/products/" + productId + "/options/" + optionId))
+                .build();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/ProductController.java
@@ -1,11 +1,14 @@
 package com.lovecloud.productmanagement.presentation;
 
 import com.lovecloud.productmanagement.application.ProductCreateService;
+import com.lovecloud.productmanagement.application.ProductOptionsCreateService;
+import com.lovecloud.productmanagement.presentation.request.CreateProductOptionRequest;
 import com.lovecloud.productmanagement.presentation.request.CreateProductRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
     private final ProductCreateService productCreateService;
+    private final ProductOptionsCreateService productOptionsCreateService;
 
     @PostMapping
     public ResponseEntity<Long> creatProduct(
@@ -26,12 +30,12 @@ public class ProductController {
         return ResponseEntity.created(URI.create("/products/" + productId)).build();
     }
 
-/*    @PostMapping("/{productId}/options")
+    @PostMapping("/{productId}/options")
     public ResponseEntity<Void> addProductOptions(
             @PathVariable Long productId,
             @Valid @RequestBody CreateProductOptionRequest request
     ) {
-        productCreateService.addProductOptions(request.toCommand(productId));
-        return ResponseEntity.created(URI.create("/products/" + productId + "/options")).build();
-    }*/
+        final Long optionId = productOptionsCreateService.addProductOptions(request.toCommand(productId));
+        return ResponseEntity.created(URI.create("/products/" + productId + "/options/" + optionId)).build();
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/presentation/ProductQueryController.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/ProductQueryController.java
@@ -1,0 +1,36 @@
+package com.lovecloud.productmanagement.presentation;
+
+import com.lovecloud.productmanagement.application.ProductQueryService;
+import com.lovecloud.productmanagement.query.response.ProductResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/products")
+@RestController
+public class ProductQueryController {
+
+    private final ProductQueryService productQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<ProductResponse>> listProducts(
+            @RequestParam(required = false) Long categoryId
+    ) {
+        final List<ProductResponse> products = productQueryService.findAllByCategoryId(categoryId);
+        return ResponseEntity.ok(products);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductResponse> detailProduct(
+            @PathVariable Long productId
+    ) {
+        final ProductResponse product = productQueryService.findById(productId);
+        return ResponseEntity.ok(product);
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductOptionRequest.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductOptionRequest.java
@@ -1,0 +1,24 @@
+package com.lovecloud.productmanagement.presentation.request;
+
+import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateProductOptionRequest(
+        @NotBlank String color,
+        @NotBlank String modelName,
+        @NotNull @Min(1) Integer price,
+        @NotNull @Min(0) Integer stockQuantity
+) {
+
+    public CreateProductOptionsCommand toCommand(Long productId) {
+        return CreateProductOptionsCommand.builder()
+                .productId(productId)
+                .color(color)
+                .modelName(modelName)
+                .price(price)
+                .stockQuantity(stockQuantity)
+                .build();
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductOptionsRequest.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductOptionsRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record CreateProductOptionRequest(
+public record CreateProductOptionsRequest(
         @NotBlank String color,
         @NotBlank String modelName,
         @NotNull @Min(1) Integer price,

--- a/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductRequest.java
+++ b/src/main/java/com/lovecloud/productmanagement/presentation/request/CreateProductRequest.java
@@ -1,0 +1,23 @@
+package com.lovecloud.productmanagement.presentation.request;
+
+import com.lovecloud.productmanagement.application.command.CreateProductCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record CreateProductRequest(
+        @NotBlank String productName,
+        @NotNull Long categoryId,
+        @NotNull List<String> mainImageNames,
+        @NotNull List<String> descriptionImageNames
+) {
+
+    public CreateProductCommand toCommand() {
+        return CreateProductCommand.builder()
+                .productName(productName)
+                .categoryId(categoryId)
+                .mainImageNames(mainImageNames)
+                .descriptionImageNames(descriptionImageNames)
+                .build();
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductResponse.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductResponse.java
@@ -1,0 +1,38 @@
+package com.lovecloud.productmanagement.query.response;
+
+import java.util.List;
+
+public record ProductResponse(
+        Long productId,
+        String productName,
+        CategoryData category,
+        List<ImageData> mainImages,
+        List<ImageData> descriptionImages,
+        List<ProductOptionsData> productOptions
+) {
+
+    public static record CategoryData(
+            Long categoryId,
+            String categoryName
+    ) {
+
+    }
+
+    public static record ImageData(
+            Long imageId,
+            String imageName
+    ) {
+
+    }
+
+    public static record ProductOptionsData(
+            Long productOptionsId,
+            String color,
+            String modelName,
+            Boolean isDeleted,
+            int price,
+            int stockQuantity
+    ) {
+
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductResponseAdapter.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductResponseAdapter.java
@@ -1,0 +1,63 @@
+package com.lovecloud.productmanagement.query.response;
+
+import com.lovecloud.productmanagement.domain.DescriptionImage;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProductResponseAdapter {
+
+    public static ProductResponse fromProduct(
+            Product product,
+            List<MainImage> mainImages,
+            List<DescriptionImage> descriptionImages,
+            List<ProductOptions> productOptions
+    ) {
+        return new ProductResponse(
+                product.getId(),
+                product.getProductName(),
+                new ProductResponse.CategoryData(
+                        product.getCategory().getId(),
+                        product.getCategory().getCategoryName()
+                ),
+                mapMainImages(mainImages),
+                mapDescriptionImages(descriptionImages),
+                mapProductOptions(productOptions)
+        );
+    }
+
+    private static List<ProductResponse.ImageData> mapMainImages(List<MainImage> mainImages) {
+        return mainImages.stream()
+                .map(image -> new ProductResponse.ImageData(
+                        image.getId(),
+                        image.getMainImageName()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ProductResponse.ImageData> mapDescriptionImages(
+            List<DescriptionImage> descriptionImages) {
+        return descriptionImages.stream()
+                .map(image -> new ProductResponse.ImageData(
+                        image.getId(),
+                        image.getDescriptionImageName()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ProductResponse.ProductOptionsData> mapProductOptions(
+            List<ProductOptions> productOptions) {
+        return productOptions.stream()
+                .map(option -> new ProductResponse.ProductOptionsData(
+                        option.getId(),
+                        option.getColor(),
+                        option.getModelName(),
+                        option.getIsDeleted(),
+                        option.getPrice(),
+                        option.getStockQuantity()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/lovecloud/LoveCloudApplicationTests.java
+++ b/src/test/java/com/lovecloud/LoveCloudApplicationTests.java
@@ -1,4 +1,4 @@
-package com.lovecloud.lovecloud;
+package com.lovecloud;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/lovecloud/productmanagement/application/ProductCreateServiceTest.java
+++ b/src/test/java/com/lovecloud/productmanagement/application/ProductCreateServiceTest.java
@@ -1,0 +1,109 @@
+package com.lovecloud.productmanagement.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.lovecloud.productmanagement.application.command.CreateProductCommand;
+import com.lovecloud.productmanagement.domain.Category;
+import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.repository.ProductRepository;
+import com.lovecloud.productmanagement.exception.NotFoundCategoryException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayName("상품 생성 서비스 (ProductCreateService) 은(는)")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ProductCreateServiceTest {
+
+    @Autowired
+    private ProductCreateService productCreateService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = new Category("에어컨");
+        category = categoryRepository.save(category);
+    }
+
+    @Nested
+    class 상품_생성_시 {
+
+        @Test
+        void 정상적으로_상품과_이미지를_생성한다() {
+            // given
+            CreateProductCommand command = CreateProductCommand.builder()
+                    .productName("BESPOKE 무풍에어컨 갤러리 청정")
+                    .categoryId(category.getId())
+                    .mainImageNames(List.of("image1.jpg"))
+                    .descriptionImageNames(List.of("detail1.jpg", "detail2.jpg"))
+                    .build();
+
+            // when
+            Long productId = productCreateService.createProduct(command);
+
+            // then
+            Product product = productRepository.findById(productId).orElseThrow();
+            assertThat(product.getProductName()).isEqualTo("BESPOKE 무풍에어컨 갤러리 청정");
+            assertThat(product.getCategory()).isEqualTo(category);
+        }
+
+        @Test
+        void 카테고리가_존재하지_않는_경우_예외를_발생시킨다() {
+            // given
+            CreateProductCommand command = CreateProductCommand.builder()
+                    .productName("BESPOKE 무풍에어컨 갤러리 청정")
+                    .categoryId(999L) // 존재하지 않는 카테고리 ID
+                    .mainImageNames(List.of("image1.jpg"))
+                    .descriptionImageNames(List.of("detail1.jpg", "detail2.jpg"))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> productCreateService.createProduct(command))
+                    .isInstanceOf(NotFoundCategoryException.class);
+        }
+
+        @Test
+        void 제품명이_중복되어도_생성된다() {
+            // given
+            productCreateService.createProduct(CreateProductCommand.builder()
+                    .productName("BESPOKE 무풍에어컨 갤러리 청정")
+                    .categoryId(category.getId())
+                    .mainImageNames(List.of("image1.jpg"))
+                    .descriptionImageNames(List.of("detail1.jpg"))
+                    .build());
+
+            CreateProductCommand secondCommand = CreateProductCommand.builder()
+                    .productName("BESPOKE 무풍에어컨 갤러리 청정")
+                    .categoryId(category.getId())
+                    .mainImageNames(List.of("image2.jpg"))
+                    .descriptionImageNames(List.of("detail2.jpg", "detail3.jpg"))
+                    .build();
+
+            // when
+            Long secondProductId = productCreateService.createProduct(secondCommand);
+
+            // then
+            Product secondProduct = productRepository.findById(secondProductId).orElseThrow();
+            assertThat(secondProduct.getProductName()).isEqualTo("BESPOKE 무풍에어컨 갤러리 청정");
+        }
+    }
+}

--- a/src/test/java/com/lovecloud/productmanagement/application/ProductCreateServiceTest.java
+++ b/src/test/java/com/lovecloud/productmanagement/application/ProductCreateServiceTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.lovecloud.productmanagement.application.command.CreateProductCommand;
 import com.lovecloud.productmanagement.domain.Category;
-import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
 import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
 import com.lovecloud.productmanagement.exception.NotFoundCategoryException;
 import jakarta.transaction.Transactional;

--- a/src/test/java/com/lovecloud/productmanagement/application/ProductOptionsCreateServiceTest.java
+++ b/src/test/java/com/lovecloud/productmanagement/application/ProductOptionsCreateServiceTest.java
@@ -1,0 +1,108 @@
+package com.lovecloud.productmanagement.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.lovecloud.productmanagement.application.command.CreateProductCommand;
+import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
+import com.lovecloud.productmanagement.domain.Category;
+import com.lovecloud.productmanagement.domain.Product;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+import com.lovecloud.productmanagement.domain.repository.CategoryRepository;
+import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
+import com.lovecloud.productmanagement.domain.repository.ProductRepository;
+import com.lovecloud.productmanagement.exception.NotFoundProductException;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+@DisplayName("상품 옵션 생성 서비스 (ProductOptionsCreateService) 은(는)")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ProductOptionsCreateServiceTest {
+
+    @Autowired
+    private ProductOptionsCreateService productOptionsCreateService;
+
+    @Autowired
+    private ProductCreateService productCreateService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductOptionsRepository productOptionsRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private Product product;
+
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = new Category("에어컨");
+        category = categoryRepository.save(category);
+
+        CreateProductCommand command = CreateProductCommand.builder()
+                .productName("BESPOKE 무풍에어컨 갤러리 청정")
+                .categoryId(category.getId())
+                .mainImageNames(List.of("image1.jpg"))
+                .descriptionImageNames(List.of("detail1.jpg", "detail2.jpg"))
+                .build();
+        Long productId = productCreateService.createProduct(command);
+        product = productRepository.findByIdOrThrow(productId);
+    }
+
+    @Nested
+    class 상품_옵션_생성_시 {
+
+        @Test
+        void 정상적으로_상품_옵션을_생성한다() {
+            // given
+            CreateProductOptionsCommand command = CreateProductOptionsCommand.builder()
+                    .productId(product.getId())
+                    .color("white")
+                    .modelName("AR06D1150HZT")
+                    .price(1000000)
+                    .stockQuantity(10)
+                    .build();
+
+            // when
+            Long optionId = productOptionsCreateService.addProductOptions(command);
+
+            // then
+            ProductOptions options = productOptionsRepository.getById(optionId);
+            assertEquals(product, options.getProduct());
+            assertEquals("white", options.getColor());
+            assertEquals("AR06D1150HZT", options.getModelName());
+            assertEquals(1000000, options.getPrice());
+            assertEquals(10, options.getStockQuantity());
+            assertEquals(false, options.getIsDeleted());
+        }
+
+        @Test
+        @DisplayName("상품이 존재하지 않는 경우 예외를 발생시킨다")
+        void 상품이_존재하지_않는_경우_예외를_발생시키다() {
+            // given
+            CreateProductOptionsCommand command = CreateProductOptionsCommand.builder()
+                    .productId(999L) // 존재하지 않는 상품 ID
+                    .color("white")
+                    .modelName("AR06D1150HZT")
+                    .price(1000000)
+                    .stockQuantity(10)
+                    .build();
+
+            // when & then
+            assertThrows(NotFoundProductException.class, () -> productOptionsCreateService.addProductOptions(command));
+        }
+    }
+}

--- a/src/test/java/com/lovecloud/productmanagement/application/ProductOptionsCreateServiceTest.java
+++ b/src/test/java/com/lovecloud/productmanagement/application/ProductOptionsCreateServiceTest.java
@@ -1,6 +1,7 @@
 package com.lovecloud.productmanagement.application;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.lovecloud.productmanagement.application.command.CreateProductCommand;
 import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
@@ -102,7 +103,8 @@ class ProductOptionsCreateServiceTest {
                     .build();
 
             // when & then
-            assertThrows(NotFoundProductException.class, () -> productOptionsCreateService.addProductOptions(command));
+            assertThrows(NotFoundProductException.class,
+                    () -> productOptionsCreateService.addProductOptions(command));
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #30 

## 💗 작업 동기
신혼 부부가 펀딩을 생성할 때, 상품 선택이 필요합니다. 상품 선택을 위한 상품 목록/상세 조회 기능이 필요하여 구현하였습니다.

## 🛠️ 작업 내용
- [x] @Transactional import를 org.springframework.transaction.annotation.Transactional으로 수정
- [x] 목록/상세 조회 API 구현
- [x] 목록/상세 조회 로직 구현
- [x] 상품 Response 레코드 ProductResponse 구현
- [x] 상품, 카테고리, 대표 이미지, 설명 이미지, 상품 옵션을 ProductResponse로 Adapter해주는 ProductResponseAdapter 구현

## 🎯 리뷰 포인트

@Transactional import를 org.springframework.transaction.annotation.Transactional로 수정하였습니다. 상세 내용은 아래 링크 참고하세요.
[어떤 @Transactional을 사용해야 할까?](https://interconnection.tistory.com/123)


## ✅ 테스트 결과

1. 모든 상품 목록을 조회

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/21e8a01e-aa1a-47de-890a-f51f7b030f21)

2. 카테고리별 상품 목록 조회

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/152332aa-561d-4d72-924b-297ef0989809)

3. 상품 상세 조회

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/ead68d68-f168-4987-90ec-8a39c1600b49)

