### PR TITLE
feat: 펀딩 종료 기능 구현

### DIFF
--- a/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
@@ -71,5 +71,9 @@ public class Funding extends CommonRootEntity<Long> {
 
     public void increaseCurrentAmount(Long amount) {
         this.currentAmount += amount;
+        if (this.currentAmount >= this.targetAmount && this.status == FundingStatus.IN_PROGRESS) {
+            this.status = FundingStatus.COMPLETED;
+            registerEvent(new FundingCompletedEvent(this.id));
+        }
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.lovecloud.fundingmanagement.domain;
+
+import com.lovecloud.global.domain.DomainEvent;
+
+public record FundingCompletedEvent(
+        Long fundingId
+) implements DomainEvent<Long> {
+
+        @Override
+        public Long id() {
+            return fundingId();
+        }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #78 

## 💗 작업 동기
Funding의 currentAmount를 증가시킬 때, Funding의 currentAmount가 targetAmount 달성 시 FundingStatus를 IN_PROGRESS에서 COMPLETED로 변경하는 기능이 필요합니다.

## 🛠️ 작업 내용
- [x] Funding 도메인에 이벤드 등록 코드 구현
- [x] 도메인 이벤트 클래스 FundingCompletedEvent 구현

## 🎯 리뷰 포인트
펀딩 종료 시 알림 전송하는 Event가 추가될 예정이라는 점을 고려하여, 스프링 이벤트를 활용하여 서비스 간의 의존성을 제거하였습니다.

## ✅ 테스트 결과
1. 펀딩 참여(펀딩 완료 조건 충족X)
- 펀딩 참여 완료 전

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/2a69683b-bb55-4a65-a9f1-4fc6bdfec9ac)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/6dd32cb3-e730-423a-bd55-7b5fdc8b9b47)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/1254c6cd-a6ff-440c-8416-ce738b77d4df)

- 펀딩 참여 완료 후
guest_funding의 participation_status는 PAID로 변경되며, 
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/867958d2-829e-48a9-8ea9-cf09c5b1ffba)

funding의 current_amount가 증가하였습니다.
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/71411115-3002-477a-988d-3fab091dc86f)

2. 펀딩 참여(펀딩 완료 조건 충족O)
- 펀딩 참여 완료 전
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/021b9c8d-f772-4472-abf5-f0b292e0f68b)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/ba40708a-7e79-45cf-9184-9f79905e6235)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/ebd438aa-5c4a-454e-b107-f717c3d53126)

- 펀딩 참여 완료 후

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/93dfc0d6-1c6e-40b9-9cb4-38da2c5a15d5)

Participation_status가 PAID로 변경되며, 
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/4e947a50-092d-485b-80de-b764c037fd24)

currentAmount 증가 후 펀딩 금액 달성하여 COMPLETED로 변경되었습니다.
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/1230af1b-3e1e-4918-825a-accc1391a1ef)


