### PR TITLE
Feat/#80 Guest 로그인

### DIFF
--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -4,6 +4,7 @@ import com.lovecloud.auth.application.command.GuestSignUpCommand;
 import com.lovecloud.auth.domain.GuestRepository;
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
@@ -44,6 +45,8 @@ public class GuestAuthService {
 
         return jwtTokenDto;
     }
+
+
 
 
 }

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,13 @@ public class GuestAuthService {
     }
 
 
+    /**
+     * 로그인을 처리하고, 토큰을 발급하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 토큰에 대한 JwtTokenDto 객체
+     * @throws
+     */
     @Transactional
     public JwtTokenDto signIn(GuestSignInRequest request){
         Guest user = guestRepository.getByEmailOrThrow(request.email());

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,15 @@ public class GuestAuthService {
     }
 
 
+    @Transactional
+    public JwtTokenDto signIn(GuestSignInRequest request){
+        Guest user = guestRepository.getByEmailOrThrow(request.email());
+        user.signIn(request.password(), passwordEncoder);
 
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+
+        return jwtTokenDto;
+    }
 
 }

--- a/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
@@ -2,6 +2,7 @@ package com.lovecloud.auth.presentation;
 
 
 import com.lovecloud.auth.application.GuestAuthService;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.auth.presentation.request.GuestSignUpRequest;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
 import jakarta.validation.Valid;
@@ -32,6 +33,20 @@ public class GuestAuthController {
         JwtTokenDto jwtTokenDto = guestAuthService.signUp(request.toCommand());
 
         log.info("유저가 생성되었습니다. {}", request.email());
+        return ResponseEntity.ok(jwtTokenDto);
+    }
+
+    /**
+     * 로그인을 처리하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 로그인 결과에 대한 JwtTokenDto 객체
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<JwtTokenDto> signIn(@Valid @RequestBody GuestSignInRequest request){
+        JwtTokenDto jwtTokenDto = guestAuthService.signIn(request);
+
+        log.info("유저가 로그인 되었습니다. {}", request.email());
         return ResponseEntity.ok(jwtTokenDto);
     }
 }

--- a/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
+++ b/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
@@ -1,4 +1,9 @@
 package com.lovecloud.auth.presentation.request;
 
-public record GuestSignInRequest() {
+import jakarta.validation.constraints.NotBlank;
+
+public record GuestSignInRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
@@ -1,11 +1,15 @@
 package com.lovecloud.fundingmanagement.application;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
+import com.lovecloud.fundingmanagement.domain.repository.GuestFundingRepository;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponseMapper;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponseMapper;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import java.util.List;
@@ -22,6 +26,7 @@ public class FundingQueryService {
     private final MainImageRepository mainImageRepository;
     private final FundingRepository fundingRepository;
     private final CoupleRepository coupleRepository;
+    private final GuestFundingRepository guestFundingRepository;
 
     public List<FundingListResponse> findAllByCoupleId(Long coupleId) {
         coupleRepository.findByIdOrThrow(coupleId);
@@ -44,5 +49,13 @@ public class FundingQueryService {
                 funding,
                 mainImageRepository.findByProductOptionsId(funding.getProductOptions().getId())
         );
+    }
+
+    public List<GuestFundingListResponse> findAllGuestFundingsByFundingId(Long fundingId) {
+        Funding funding = fundingRepository.findByIdOrThrow(fundingId);
+        return guestFundingRepository.findByFundingIdAndParticipationStatus(fundingId,
+                        ParticipationStatus.PAID).stream()
+                .map(GuestFundingListResponseMapper::mapGuestFundingToGuestFundingListResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
@@ -2,6 +2,8 @@ package com.lovecloud.fundingmanagement.application;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponseMapper;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
@@ -34,5 +36,13 @@ public class FundingQueryService {
                                 funding.getProductOptions().getId())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public FundingDetailResponse findById(Long fundingId) {
+        Funding funding = fundingRepository.findByIdOrThrow(fundingId);
+        return FundingDetailResponseMapper.mapFundingToFundingDetailResponse(
+                funding,
+                mainImageRepository.findByProductOptionsId(funding.getProductOptions().getId())
+        );
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
@@ -71,5 +71,9 @@ public class Funding extends CommonRootEntity<Long> {
 
     public void increaseCurrentAmount(Long amount) {
         this.currentAmount += amount;
+        if (this.currentAmount >= this.targetAmount && this.status == FundingStatus.IN_PROGRESS) {
+            this.status = FundingStatus.COMPLETED;
+            registerEvent(new FundingCompletedEvent(this.id));
+        }
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.lovecloud.fundingmanagement.domain;
+
+import com.lovecloud.global.domain.DomainEvent;
+
+public record FundingCompletedEvent(
+        Long fundingId
+) implements DomainEvent<Long> {
+
+        @Override
+        public Long id() {
+            return fundingId();
+        }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
@@ -1,12 +1,16 @@
 package com.lovecloud.fundingmanagement.domain.repository;
 
 import com.lovecloud.fundingmanagement.domain.GuestFunding;
+import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.exception.NotFoundGuestFundingException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GuestFundingRepository extends JpaRepository<GuestFunding, Long> {
+
+    List<GuestFunding> findByFundingIdAndParticipationStatus(Long fundingId, ParticipationStatus participationStatus);
 
     default GuestFunding findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundGuestFundingException::new);

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -3,6 +3,7 @@ package com.lovecloud.fundingmanagement.presentation;
 import com.lovecloud.fundingmanagement.application.FundingQueryService;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +31,14 @@ public class FundingQueryController {
     ) {
         final FundingDetailResponse funding = fundingQueryService.findById(fundingId);
         return ResponseEntity.ok(funding);
+    }
+
+    @GetMapping("/fundings/{fundingId}/guest-fundings")
+    public ResponseEntity<List<GuestFundingListResponse>> listGuestFundings(
+            @PathVariable Long fundingId
+    ) {
+        final List<GuestFundingListResponse> guestFundings =
+                fundingQueryService.findAllGuestFundingsByFundingId(fundingId);
+        return ResponseEntity.ok(guestFundings);
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -1,6 +1,7 @@
 package com.lovecloud.fundingmanagement.presentation;
 
 import com.lovecloud.fundingmanagement.application.FundingQueryService;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +24,11 @@ public class FundingQueryController {
         return ResponseEntity.ok(fundings);
     }
 
-/*    @GetMapping("/fundings/{fundingId}")
+    @GetMapping("/fundings/{fundingId}")
     public ResponseEntity<FundingDetailResponse> detailFunding(
             @PathVariable Long fundingId
     ) {
         final FundingDetailResponse funding = fundingQueryService.findById(fundingId);
         return ResponseEntity.ok(funding);
-    }*/
+    }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
@@ -1,0 +1,46 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.FundingStatus;
+import com.lovecloud.usermanagement.domain.WeddingRole;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FundingDetailResponse(
+        Long fundingId,
+        String title,
+        String message,
+        long targetAmount,
+        long currentAmount,
+        FundingStatus status,
+        LocalDateTime endDate,
+        ProductOptionsSummary productOptions,
+        CoupleSummary couple
+) {
+
+    public static record ProductOptionsSummary(
+            Long productOptionsId,
+            List<ImageData> mainImages
+    ) {
+
+        public static record ImageData(
+                Long imageId,
+                String imageName
+        ) {
+
+        }
+    }
+
+    public static record CoupleSummary(
+            Long coupleId,
+            List<Person> people
+    ) {
+
+        public static record Person(
+                String phoneNumber,
+                WeddingRole weddingRole,
+                String name
+        ) {
+
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
@@ -1,0 +1,64 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.usermanagement.domain.WeddingUser;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FundingDetailResponseMapper {
+
+    public static FundingDetailResponse mapFundingToFundingDetailResponse(Funding funding,
+            List<MainImage> mainImages) {
+        FundingDetailResponse.ProductOptionsSummary productOptionsSummary = mapToProductOptionsSummary(
+                funding.getProductOptions().getId(), mainImages);
+
+        FundingDetailResponse.CoupleSummary coupleSummary = mapToCoupleSummary(funding);
+
+        return new FundingDetailResponse(
+                funding.getId(),
+                funding.getTitle(),
+                funding.getMessage(),
+                funding.getTargetAmount(),
+                funding.getCurrentAmount(),
+                funding.getStatus(),
+                funding.getEndDate(),
+                productOptionsSummary,
+                coupleSummary
+        );
+    }
+
+    private static FundingDetailResponse.ProductOptionsSummary mapToProductOptionsSummary(
+            Long productOptionsId, List<MainImage> mainImages) {
+        return new FundingDetailResponse.ProductOptionsSummary(
+                productOptionsId,
+                mainImages.stream()
+                        .map(image -> new FundingDetailResponse.ProductOptionsSummary.ImageData(
+                                image.getId(), image.getMainImageName()))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private static FundingDetailResponse.CoupleSummary mapToCoupleSummary(Funding funding) {
+        WeddingUser groom = funding.getCouple().getGroom();
+        WeddingUser bride = funding.getCouple().getBride();
+
+        List<FundingDetailResponse.CoupleSummary.Person> people = List.of(
+                new FundingDetailResponse.CoupleSummary.Person(
+                        groom.getPhoneNumber(),
+                        groom.getWeddingRole(),
+                        groom.getName()
+                ),
+                new FundingDetailResponse.CoupleSummary.Person(
+                        bride.getPhoneNumber(),
+                        bride.getWeddingRole(),
+                        bride.getName()
+                )
+        );
+
+        return new FundingDetailResponse.CoupleSummary(
+                funding.getCouple().getId(),
+                people
+        );
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponse.java
@@ -1,0 +1,13 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import java.time.LocalDateTime;
+
+public record GuestFundingListResponse(
+        Long guestFundingId,
+        String name,
+        long fundingAmount,
+        String message,
+        LocalDateTime paidAt
+) {
+
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
@@ -1,0 +1,18 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.GuestFunding;
+
+public class GuestFundingListResponseMapper {
+
+    public static GuestFundingListResponse mapGuestFundingToGuestFundingListResponse(
+            GuestFunding guestFunding) {
+        return new GuestFundingListResponse(
+                guestFunding.getId(),
+                guestFunding.getName(),
+                guestFunding.getFundingAmount(),
+                guestFunding.getMessage(),
+                guestFunding.getPayment().getPaidAt()
+        );
+    }
+
+}

--- a/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
@@ -2,6 +2,7 @@ package com.lovecloud.usermanagement.domain;
 
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -37,5 +38,9 @@ public class Guest extends User {
 
     public String getPassword() {
         return password.getEncryptedPassword();
+    }
+
+    public void signIn(String rawPassword, CustomPasswordEncoder passwordEncoder){
+        this.password.validatePassword(rawPassword, passwordEncoder);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #80 
closed #81 
closed #82 
closed #83 

## 💗 작업 동기
Guest 로그인 구현 완료

## 🛠️ 작업 내용
- [x] GuestSignInRequest 작성
- [x] Guest 엔티티에 signIn 메서드 구현
- [x] GuestAuthService에 signIn 메서드 구현
- [x] GuestAuthController에 signIn 메서드 구현

## 🎯 리뷰 포인트
- WeddingUser와 Guest의 이메일 중복건

현재 WeddingUser와 Guest를 가입할 때 중복된 이메일로 가입할 수 있도록 email 중복 검사를 weddingUser와 guest 각각 진행하도록 하였습니다.
이에 따라 하나의 email로 weddingUser와 guest 모두 가입할 수 있는데,  새로운 토큰 발급에서 문제가 발생했습니다.

AuthController에 구현된 reCreateToken 메서드는 refreshToken을 통해 accessToken과 refreshToken을 새로 발급하는 메서드인데, refreshToken 유효성을 검사할 때 email이 중복되면 둘 중 어느 유저인지 찾지 못해 발급이 불가능 합니다.

따라서 jwtTokenProvider를 전반적으로 수정할 예정입니다.


## ✅ 테스트 결과

postman 요청 결과
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/103185987/2683d3d1-7783-4bbf-8ed9-043e35cc832b)

