### PR TITLE
Feat/#85 TokenProvider 로직 수정

### DIFF
--- a/src/main/java/com/lovecloud/auth/application/AuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package com.lovecloud.auth.application;
 
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
+import com.lovecloud.usermanagement.domain.UserRole;
 import com.lovecloud.usermanagement.domain.WeddingUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,15 +34,16 @@ public class AuthService {
     }
 
     /**
-     * User email로 JwtTokenDto를 생성하는 메서드
+     * User email, userRole으로 JwtTokenDto를 생성하는 메서드
      *
      * @param email User email
+     * @param userRole User userRole
      * @return JwtTokenDto
      */
-    public JwtTokenDto createJwtTokenDto(String email){
+    public JwtTokenDto createJwtTokenDto(String email, UserRole userRole){
 
-        String accessToken = jwtTokenProvider.createAccessToken(email);
-        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+        String accessToken = jwtTokenProvider.createAccessToken(email, userRole);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email, userRole);
 
         return JwtTokenDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -4,6 +4,7 @@ import com.lovecloud.auth.application.command.GuestSignUpCommand;
 import com.lovecloud.auth.domain.GuestRepository;
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
@@ -44,6 +45,8 @@ public class GuestAuthService {
 
         return jwtTokenDto;
     }
+
+
 
 
 }

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -40,8 +40,8 @@ public class GuestAuthService {
 
         guestRepository.save(user);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }
@@ -59,8 +59,8 @@ public class GuestAuthService {
         Guest user = guestRepository.getByEmailOrThrow(request.email());
         user.signIn(request.password(), passwordEncoder);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,13 @@ public class GuestAuthService {
     }
 
 
+    /**
+     * 로그인을 처리하고, 토큰을 발급하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 토큰에 대한 JwtTokenDto 객체
+     * @throws
+     */
     @Transactional
     public JwtTokenDto signIn(GuestSignInRequest request){
         Guest user = guestRepository.getByEmailOrThrow(request.email());

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,15 @@ public class GuestAuthService {
     }
 
 
+    @Transactional
+    public JwtTokenDto signIn(GuestSignInRequest request){
+        Guest user = guestRepository.getByEmailOrThrow(request.email());
+        user.signIn(request.password(), passwordEncoder);
 
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+
+        return jwtTokenDto;
+    }
 
 }

--- a/src/main/java/com/lovecloud/auth/application/WeddingUserAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/WeddingUserAuthService.java
@@ -45,8 +45,8 @@ public class WeddingUserAuthService {
 
         weddingUserRepository.save(user);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }
@@ -63,8 +63,8 @@ public class WeddingUserAuthService {
         WeddingUser user = weddingUserRepository.getByEmailOrThrow(request.email());
         user.signIn(request.password(), passwordEncoder);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }

--- a/src/main/java/com/lovecloud/auth/presentation/AuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/AuthController.java
@@ -4,6 +4,7 @@ import com.lovecloud.auth.application.AuthService;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
 import com.lovecloud.global.jwt.refresh.RefreshTokenService;
+import com.lovecloud.usermanagement.domain.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,8 @@ public class AuthController {
             @RequestHeader("Authorization") String refreshTokenHeader) {
 
         String refreshToken = refreshTokenHeader.substring(7).trim();
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        UserRole userType = jwtTokenProvider.getUserRole(refreshToken);
 
         String newAccessToken = refreshTokenService.reCreateAccessTokenByRefreshToken(refreshToken);
         String newRefreshToken = refreshTokenService.reCreateRefreshTokenByRefreshToken(refreshToken);
@@ -42,9 +45,9 @@ public class AuthController {
                 .refreshToken(newRefreshToken)
                 .build();
 
-        refreshTokenService.createRefreshToken(jwtTokenDto, jwtTokenProvider.getUsername(refreshToken));
+        refreshTokenService.createRefreshToken(jwtTokenDto, username, userType);
 
-        log.info("토큰이 재생성 되었습니다. {}", jwtTokenProvider.getUsername(refreshToken));
+        log.info("토큰이 재생성 되었습니다. {} , {}", jwtTokenProvider.getUsername(refreshToken), jwtTokenProvider.getUserRole(refreshToken));
         return ResponseEntity.ok(jwtTokenDto);
     }
 

--- a/src/main/java/com/lovecloud/auth/presentation/AuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
 
         String refreshToken = refreshTokenHeader.substring(7).trim();
         String username = jwtTokenProvider.getUsername(refreshToken);
-        UserRole userType = jwtTokenProvider.getUserRole(refreshToken);
+        UserRole userRole = jwtTokenProvider.getUserRole(refreshToken);
 
         String newAccessToken = refreshTokenService.reCreateAccessTokenByRefreshToken(refreshToken);
         String newRefreshToken = refreshTokenService.reCreateRefreshTokenByRefreshToken(refreshToken);
@@ -45,7 +45,7 @@ public class AuthController {
                 .refreshToken(newRefreshToken)
                 .build();
 
-        refreshTokenService.createRefreshToken(jwtTokenDto, username, userType);
+        refreshTokenService.createRefreshToken(jwtTokenDto, username, userRole);
 
         log.info("토큰이 재생성 되었습니다. {} , {}", jwtTokenProvider.getUsername(refreshToken), jwtTokenProvider.getUserRole(refreshToken));
         return ResponseEntity.ok(jwtTokenDto);

--- a/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
@@ -2,6 +2,7 @@ package com.lovecloud.auth.presentation;
 
 
 import com.lovecloud.auth.application.GuestAuthService;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.auth.presentation.request.GuestSignUpRequest;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
 import jakarta.validation.Valid;
@@ -32,6 +33,20 @@ public class GuestAuthController {
         JwtTokenDto jwtTokenDto = guestAuthService.signUp(request.toCommand());
 
         log.info("유저가 생성되었습니다. {}", request.email());
+        return ResponseEntity.ok(jwtTokenDto);
+    }
+
+    /**
+     * 로그인을 처리하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 로그인 결과에 대한 JwtTokenDto 객체
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<JwtTokenDto> signIn(@Valid @RequestBody GuestSignInRequest request){
+        JwtTokenDto jwtTokenDto = guestAuthService.signIn(request);
+
+        log.info("유저가 로그인 되었습니다. {}", request.email());
         return ResponseEntity.ok(jwtTokenDto);
     }
 }

--- a/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
+++ b/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
@@ -1,4 +1,9 @@
 package com.lovecloud.auth.presentation.request;
 
-public record GuestSignInRequest() {
+import jakarta.validation.constraints.NotBlank;
+
+public record GuestSignInRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
@@ -1,11 +1,15 @@
 package com.lovecloud.fundingmanagement.application;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
+import com.lovecloud.fundingmanagement.domain.repository.GuestFundingRepository;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponseMapper;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponseMapper;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import java.util.List;
@@ -22,6 +26,7 @@ public class FundingQueryService {
     private final MainImageRepository mainImageRepository;
     private final FundingRepository fundingRepository;
     private final CoupleRepository coupleRepository;
+    private final GuestFundingRepository guestFundingRepository;
 
     public List<FundingListResponse> findAllByCoupleId(Long coupleId) {
         coupleRepository.findByIdOrThrow(coupleId);
@@ -44,5 +49,13 @@ public class FundingQueryService {
                 funding,
                 mainImageRepository.findByProductOptionsId(funding.getProductOptions().getId())
         );
+    }
+
+    public List<GuestFundingListResponse> findAllGuestFundingsByFundingId(Long fundingId) {
+        Funding funding = fundingRepository.findByIdOrThrow(fundingId);
+        return guestFundingRepository.findByFundingIdAndParticipationStatus(fundingId,
+                        ParticipationStatus.PAID).stream()
+                .map(GuestFundingListResponseMapper::mapGuestFundingToGuestFundingListResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
@@ -2,6 +2,8 @@ package com.lovecloud.fundingmanagement.application;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponseMapper;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
@@ -34,5 +36,13 @@ public class FundingQueryService {
                                 funding.getProductOptions().getId())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public FundingDetailResponse findById(Long fundingId) {
+        Funding funding = fundingRepository.findByIdOrThrow(fundingId);
+        return FundingDetailResponseMapper.mapFundingToFundingDetailResponse(
+                funding,
+                mainImageRepository.findByProductOptionsId(funding.getProductOptions().getId())
+        );
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
@@ -71,5 +71,9 @@ public class Funding extends CommonRootEntity<Long> {
 
     public void increaseCurrentAmount(Long amount) {
         this.currentAmount += amount;
+        if (this.currentAmount >= this.targetAmount && this.status == FundingStatus.IN_PROGRESS) {
+            this.status = FundingStatus.COMPLETED;
+            registerEvent(new FundingCompletedEvent(this.id));
+        }
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/FundingCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.lovecloud.fundingmanagement.domain;
+
+import com.lovecloud.global.domain.DomainEvent;
+
+public record FundingCompletedEvent(
+        Long fundingId
+) implements DomainEvent<Long> {
+
+        @Override
+        public Long id() {
+            return fundingId();
+        }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
@@ -1,12 +1,16 @@
 package com.lovecloud.fundingmanagement.domain.repository;
 
 import com.lovecloud.fundingmanagement.domain.GuestFunding;
+import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.exception.NotFoundGuestFundingException;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GuestFundingRepository extends JpaRepository<GuestFunding, Long> {
+
+    List<GuestFunding> findByFundingIdAndParticipationStatus(Long fundingId, ParticipationStatus participationStatus);
 
     default GuestFunding findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundGuestFundingException::new);

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -3,6 +3,7 @@ package com.lovecloud.fundingmanagement.presentation;
 import com.lovecloud.fundingmanagement.application.FundingQueryService;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
+import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +31,14 @@ public class FundingQueryController {
     ) {
         final FundingDetailResponse funding = fundingQueryService.findById(fundingId);
         return ResponseEntity.ok(funding);
+    }
+
+    @GetMapping("/fundings/{fundingId}/guest-fundings")
+    public ResponseEntity<List<GuestFundingListResponse>> listGuestFundings(
+            @PathVariable Long fundingId
+    ) {
+        final List<GuestFundingListResponse> guestFundings =
+                fundingQueryService.findAllGuestFundingsByFundingId(fundingId);
+        return ResponseEntity.ok(guestFundings);
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -1,6 +1,7 @@
 package com.lovecloud.fundingmanagement.presentation;
 
 import com.lovecloud.fundingmanagement.application.FundingQueryService;
+import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +24,11 @@ public class FundingQueryController {
         return ResponseEntity.ok(fundings);
     }
 
-/*    @GetMapping("/fundings/{fundingId}")
+    @GetMapping("/fundings/{fundingId}")
     public ResponseEntity<FundingDetailResponse> detailFunding(
             @PathVariable Long fundingId
     ) {
         final FundingDetailResponse funding = fundingQueryService.findById(fundingId);
         return ResponseEntity.ok(funding);
-    }*/
+    }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
@@ -1,0 +1,46 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.FundingStatus;
+import com.lovecloud.usermanagement.domain.WeddingRole;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FundingDetailResponse(
+        Long fundingId,
+        String title,
+        String message,
+        long targetAmount,
+        long currentAmount,
+        FundingStatus status,
+        LocalDateTime endDate,
+        ProductOptionsSummary productOptions,
+        CoupleSummary couple
+) {
+
+    public static record ProductOptionsSummary(
+            Long productOptionsId,
+            List<ImageData> mainImages
+    ) {
+
+        public static record ImageData(
+                Long imageId,
+                String imageName
+        ) {
+
+        }
+    }
+
+    public static record CoupleSummary(
+            Long coupleId,
+            List<Person> people
+    ) {
+
+        public static record Person(
+                String phoneNumber,
+                WeddingRole weddingRole,
+                String name
+        ) {
+
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
@@ -1,0 +1,64 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.productmanagement.domain.MainImage;
+import com.lovecloud.usermanagement.domain.WeddingUser;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FundingDetailResponseMapper {
+
+    public static FundingDetailResponse mapFundingToFundingDetailResponse(Funding funding,
+            List<MainImage> mainImages) {
+        FundingDetailResponse.ProductOptionsSummary productOptionsSummary = mapToProductOptionsSummary(
+                funding.getProductOptions().getId(), mainImages);
+
+        FundingDetailResponse.CoupleSummary coupleSummary = mapToCoupleSummary(funding);
+
+        return new FundingDetailResponse(
+                funding.getId(),
+                funding.getTitle(),
+                funding.getMessage(),
+                funding.getTargetAmount(),
+                funding.getCurrentAmount(),
+                funding.getStatus(),
+                funding.getEndDate(),
+                productOptionsSummary,
+                coupleSummary
+        );
+    }
+
+    private static FundingDetailResponse.ProductOptionsSummary mapToProductOptionsSummary(
+            Long productOptionsId, List<MainImage> mainImages) {
+        return new FundingDetailResponse.ProductOptionsSummary(
+                productOptionsId,
+                mainImages.stream()
+                        .map(image -> new FundingDetailResponse.ProductOptionsSummary.ImageData(
+                                image.getId(), image.getMainImageName()))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private static FundingDetailResponse.CoupleSummary mapToCoupleSummary(Funding funding) {
+        WeddingUser groom = funding.getCouple().getGroom();
+        WeddingUser bride = funding.getCouple().getBride();
+
+        List<FundingDetailResponse.CoupleSummary.Person> people = List.of(
+                new FundingDetailResponse.CoupleSummary.Person(
+                        groom.getPhoneNumber(),
+                        groom.getWeddingRole(),
+                        groom.getName()
+                ),
+                new FundingDetailResponse.CoupleSummary.Person(
+                        bride.getPhoneNumber(),
+                        bride.getWeddingRole(),
+                        bride.getName()
+                )
+        );
+
+        return new FundingDetailResponse.CoupleSummary(
+                funding.getCouple().getId(),
+                people
+        );
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponse.java
@@ -1,0 +1,13 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import java.time.LocalDateTime;
+
+public record GuestFundingListResponse(
+        Long guestFundingId,
+        String name,
+        long fundingAmount,
+        String message,
+        LocalDateTime paidAt
+) {
+
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
@@ -1,0 +1,18 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.GuestFunding;
+
+public class GuestFundingListResponseMapper {
+
+    public static GuestFundingListResponse mapGuestFundingToGuestFundingListResponse(
+            GuestFunding guestFunding) {
+        return new GuestFundingListResponse(
+                guestFunding.getId(),
+                guestFunding.getName(),
+                guestFunding.getFundingAmount(),
+                guestFunding.getMessage(),
+                guestFunding.getPayment().getPaidAt()
+        );
+    }
+
+}

--- a/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationProvider.java
@@ -2,6 +2,7 @@ package com.lovecloud.global.jwt;
 
 import com.lovecloud.global.usermanager.JpaUserDetailsService;
 import com.lovecloud.global.usermanager.SecurityUser;
+import com.lovecloud.usermanagement.domain.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,7 +22,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         String token = (String) authentication.getCredentials();
         if (jwtTokenProvider.validateToken(token)) {
             String username = jwtTokenProvider.getUsername(token);
-            SecurityUser userDetails = userDetailsService.loadUserByUsername(username);
+            UserRole userRole = jwtTokenProvider.getUserRole(token);
+            SecurityUser userDetails = userDetailsService.loadUserByUsernameAndRole(username, userRole);
             return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
         }
         return null;

--- a/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import com.lovecloud.global.jwt.exception.*;
 import com.lovecloud.global.jwt.refresh.RefreshToken;
 import com.lovecloud.global.jwt.refresh.RefreshTokenRepository;
 import com.lovecloud.global.usermanager.JpaUserDetailsService;
+import com.lovecloud.usermanagement.domain.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -67,16 +68,20 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
+
     /**
      * AccessToken을 발급하는 메서드
      *
-     * @param username AccessToken을 발급받을 사용자의 ID
+     * @param username AccessToken을 발급받을 사용자의 email
+     * @param userRole AccessToken을 발급받을 사용자의 역할 (UserRole)
      * @return 생성된 AccessToken 문자열
      */
-    public String createAccessToken(String username) {
+    public String createAccessToken(String username, UserRole userRole) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("userRole", userRole);
 
         return Jwts.builder()
-                .setSubject(username)
+                .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + tokenExpirationTime))
@@ -128,14 +133,18 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 주어진 사용자 이름을 기반으로 RefreshToken을 생성하는 메서드
+     * 주어진 email과 UserRole 기반으로 RefreshToken을 생성하는 메서드
      *
-     * @param username RefreshToken을 발급받을 사용자의 이름
+     * @param username RefreshToken을 발급받을 사용자의 email
+     * @param userRole RefreshToken을 발급받을 사용자의 역할 (UserRole)
      * @return 생성된 Refresh Token 문자열
      */
-    public String createRefreshToken(String username) {
+    public String createRefreshToken(String username, UserRole userRole) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("userRole", userRole);
+
         return Jwts.builder()
-                .setSubject(username)
+                .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(Date.from(Instant.now().plus(14, ChronoUnit.DAYS)))

--- a/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
@@ -180,7 +180,7 @@ public class JwtTokenProvider {
         String username = getUsername(refreshToken);
         UserRole userRole = getUserRole(refreshToken);
 
-        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUsername(username, userRole);
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUsernameAndUserRole(username, userRole);
 
         if (existingToken.isPresent()) {
             String existRefreshToken = existingToken.get().getRefreshToken();

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshToken.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.lovecloud.global.jwt.refresh;
 
+import com.lovecloud.usermanagement.domain.UserRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,14 +20,19 @@ public class RefreshToken {
     @Column(nullable = false, length = 60)
     private String username;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole userRole;
+
     @Column(nullable = false)
     private String refreshToken;
 
     @Builder
-    public RefreshToken(Long id, String refreshToken, String username) {
+    public RefreshToken(Long id, String refreshToken, String username, UserRole userRole) {
         this.id = id;
         this.refreshToken = refreshToken;
         this.username = username;
+        this.userRole = userRole;
     }
 }
 

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenRepository.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package com.lovecloud.global.jwt.refresh;
 
+import com.lovecloud.usermanagement.domain.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
 
 
-    Optional<RefreshToken> findByUsername(String email);
+    Optional<RefreshToken> findByUsernameAndUserRole(String email, UserRole userRole);
 
-    void deleteByUsername(String email);
+    void deleteByUsernameAndUserRole(String email, UserRole userRole);
 }

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenService.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenService.java
@@ -1,12 +1,13 @@
 package com.lovecloud.global.jwt.refresh;
 
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
+import com.lovecloud.usermanagement.domain.UserRole;
 
 public interface RefreshTokenService {
 
-    void createRefreshToken(JwtTokenDto jwtTokenDto, String username);
+    void createRefreshToken(JwtTokenDto jwtTokenDto, String username, UserRole userRole);
 
-    void deleteRefreshToken(JwtTokenDto jwtTokenDto, String username);
+    void deleteRefreshToken(JwtTokenDto jwtTokenDto, String username, UserRole userRole);
 
     String reCreateAccessTokenByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
+++ b/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.lovecloud.global.usermanager;
 
 import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.domain.UserRole;
 import com.lovecloud.usermanagement.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -21,6 +22,16 @@ public class JpaUserDetailsService implements UserDetailsService {
         Optional<User> user = userRepository.findByEmail(email);
 
         if(user.isPresent()) {
+            return new SecurityUser(user.get());
+        } else {
+            throw new UsernameNotFoundException("User not found");
+        }
+    }
+
+    public SecurityUser loadUserByUsernameAndRole(String email, UserRole userRole) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findByEmailAndUserRole(email, userRole);
+
+        if (user.isPresent()) {
             return new SecurityUser(user.get());
         } else {
             throw new UsernameNotFoundException("User not found");

--- a/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
@@ -2,6 +2,7 @@ package com.lovecloud.usermanagement.domain;
 
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -37,5 +38,9 @@ public class Guest extends User {
 
     public String getPassword() {
         return password.getEncryptedPassword();
+    }
+
+    public void signIn(String rawPassword, CustomPasswordEncoder passwordEncoder){
+        this.password.validatePassword(rawPassword, passwordEncoder);
     }
 }

--- a/src/main/java/com/lovecloud/usermanagement/domain/repository/UserRepository.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.lovecloud.usermanagement.domain.repository;
 
 import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.domain.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndUserRole(String email, UserRole userRole);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #85 
closed #86 
closed #87 
closed #88 
closed #89 
closed #90 
closed #91 

## 💗 작업 동기
TokenProvider 로직 수정 완료

## 🛠️ 작업 내용
- [x] accessToken, refreshToken 발급 정보에 userRole 추가
- [x] getUserRole 메서드 구현
- [x] refreshToken 엔티티에 userRole 추가 및 관련 메서드에 userRole 로직 추가
- [x] AuthController reCreateToken 로직 수정
- [x] authService, GuestAuthService, WeddingUserAuthService 관련 메서드 로직 수정
- [x] JwtAuthenticationProvider, JpaUserDetailsService에 user를 찾을 때 userRole도 함께 검사하도록 변경
- [x] UserRepository findByEmailAndUserRole 추가

## 🎯 리뷰 포인트
- RefreshToken 엔티티에 userRole 정보 추가로 인해 DB create로 변경해놨습니다.


- 기존 email로만 token을 발급하고, user 정보를 가져왔음
-> email과 userRole을 함께 사용하여 token을 발급하고 user 정보를 가져옴

토큰 발급 및 user 인증 로직에서 놓친 부분이 없는지 봐주시면 될것 같습니다.

## ✅ 테스트 결과
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/103185987/1327bf46-45d5-4f93-ac72-bcd5d3d30ab9)

같은 email을 가진 Guest, WeddingUser 모두 정상적으로 새로운 토큰 발급


