### PR TITLE
Fix/#103 global exception handler에 의한 AccessDeniedHandler and AuthenticationEntryPoint의 not work 해결

### DIFF
--- a/src/main/java/com/lovecloud/auth/application/AuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package com.lovecloud.auth.application;
 
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
+import com.lovecloud.usermanagement.domain.UserRole;
 import com.lovecloud.usermanagement.domain.WeddingUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,15 +34,16 @@ public class AuthService {
     }
 
     /**
-     * User email로 JwtTokenDto를 생성하는 메서드
+     * User email, userRole으로 JwtTokenDto를 생성하는 메서드
      *
      * @param email User email
+     * @param userRole User userRole
      * @return JwtTokenDto
      */
-    public JwtTokenDto createJwtTokenDto(String email){
+    public JwtTokenDto createJwtTokenDto(String email, UserRole userRole){
 
-        String accessToken = jwtTokenProvider.createAccessToken(email);
-        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+        String accessToken = jwtTokenProvider.createAccessToken(email, userRole);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email, userRole);
 
         return JwtTokenDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -4,6 +4,7 @@ import com.lovecloud.auth.application.command.GuestSignUpCommand;
 import com.lovecloud.auth.domain.GuestRepository;
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
@@ -44,6 +45,8 @@ public class GuestAuthService {
 
         return jwtTokenDto;
     }
+
+
 
 
 }

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -40,8 +40,8 @@ public class GuestAuthService {
 
         guestRepository.save(user);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }
@@ -59,8 +59,8 @@ public class GuestAuthService {
         Guest user = guestRepository.getByEmailOrThrow(request.email());
         user.signIn(request.password(), passwordEncoder);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,13 @@ public class GuestAuthService {
     }
 
 
+    /**
+     * 로그인을 처리하고, 토큰을 발급하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 토큰에 대한 JwtTokenDto 객체
+     * @throws
+     */
     @Transactional
     public JwtTokenDto signIn(GuestSignInRequest request){
         Guest user = guestRepository.getByEmailOrThrow(request.email());

--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -47,6 +47,15 @@ public class GuestAuthService {
     }
 
 
+    @Transactional
+    public JwtTokenDto signIn(GuestSignInRequest request){
+        Guest user = guestRepository.getByEmailOrThrow(request.email());
+        user.signIn(request.password(), passwordEncoder);
 
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+
+        return jwtTokenDto;
+    }
 
 }

--- a/src/main/java/com/lovecloud/auth/application/WeddingUserAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/WeddingUserAuthService.java
@@ -45,8 +45,8 @@ public class WeddingUserAuthService {
 
         weddingUserRepository.save(user);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }
@@ -63,8 +63,8 @@ public class WeddingUserAuthService {
         WeddingUser user = weddingUserRepository.getByEmailOrThrow(request.email());
         user.signIn(request.password(), passwordEncoder);
 
-        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail());
-        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail());
+        JwtTokenDto jwtTokenDto = authService.createJwtTokenDto(user.getEmail(), user.getUserRole());
+        refreshTokenService.createRefreshToken(jwtTokenDto, user.getEmail(), user.getUserRole());
 
         return jwtTokenDto;
     }

--- a/src/main/java/com/lovecloud/auth/presentation/AuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/AuthController.java
@@ -4,6 +4,7 @@ import com.lovecloud.auth.application.AuthService;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
 import com.lovecloud.global.jwt.refresh.RefreshTokenService;
+import com.lovecloud.usermanagement.domain.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,8 @@ public class AuthController {
             @RequestHeader("Authorization") String refreshTokenHeader) {
 
         String refreshToken = refreshTokenHeader.substring(7).trim();
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        UserRole userType = jwtTokenProvider.getUserRole(refreshToken);
 
         String newAccessToken = refreshTokenService.reCreateAccessTokenByRefreshToken(refreshToken);
         String newRefreshToken = refreshTokenService.reCreateRefreshTokenByRefreshToken(refreshToken);
@@ -42,9 +45,9 @@ public class AuthController {
                 .refreshToken(newRefreshToken)
                 .build();
 
-        refreshTokenService.createRefreshToken(jwtTokenDto, jwtTokenProvider.getUsername(refreshToken));
+        refreshTokenService.createRefreshToken(jwtTokenDto, username, userType);
 
-        log.info("토큰이 재생성 되었습니다. {}", jwtTokenProvider.getUsername(refreshToken));
+        log.info("토큰이 재생성 되었습니다. {} , {}", jwtTokenProvider.getUsername(refreshToken), jwtTokenProvider.getUserRole(refreshToken));
         return ResponseEntity.ok(jwtTokenDto);
     }
 

--- a/src/main/java/com/lovecloud/auth/presentation/AuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
 
         String refreshToken = refreshTokenHeader.substring(7).trim();
         String username = jwtTokenProvider.getUsername(refreshToken);
-        UserRole userType = jwtTokenProvider.getUserRole(refreshToken);
+        UserRole userRole = jwtTokenProvider.getUserRole(refreshToken);
 
         String newAccessToken = refreshTokenService.reCreateAccessTokenByRefreshToken(refreshToken);
         String newRefreshToken = refreshTokenService.reCreateRefreshTokenByRefreshToken(refreshToken);
@@ -45,7 +45,7 @@ public class AuthController {
                 .refreshToken(newRefreshToken)
                 .build();
 
-        refreshTokenService.createRefreshToken(jwtTokenDto, username, userType);
+        refreshTokenService.createRefreshToken(jwtTokenDto, username, userRole);
 
         log.info("토큰이 재생성 되었습니다. {} , {}", jwtTokenProvider.getUsername(refreshToken), jwtTokenProvider.getUserRole(refreshToken));
         return ResponseEntity.ok(jwtTokenDto);

--- a/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
+++ b/src/main/java/com/lovecloud/auth/presentation/GuestAuthController.java
@@ -2,6 +2,7 @@ package com.lovecloud.auth.presentation;
 
 
 import com.lovecloud.auth.application.GuestAuthService;
+import com.lovecloud.auth.presentation.request.GuestSignInRequest;
 import com.lovecloud.auth.presentation.request.GuestSignUpRequest;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
 import jakarta.validation.Valid;
@@ -32,6 +33,20 @@ public class GuestAuthController {
         JwtTokenDto jwtTokenDto = guestAuthService.signUp(request.toCommand());
 
         log.info("유저가 생성되었습니다. {}", request.email());
+        return ResponseEntity.ok(jwtTokenDto);
+    }
+
+    /**
+     * 로그인을 처리하는 메서드
+     *
+     * @param request 로그인에 필요한 정보를 담은 GuestSignInRequest 객체
+     * @return 로그인 결과에 대한 JwtTokenDto 객체
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<JwtTokenDto> signIn(@Valid @RequestBody GuestSignInRequest request){
+        JwtTokenDto jwtTokenDto = guestAuthService.signIn(request);
+
+        log.info("유저가 로그인 되었습니다. {}", request.email());
         return ResponseEntity.ok(jwtTokenDto);
     }
 }

--- a/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
+++ b/src/main/java/com/lovecloud/auth/presentation/request/GuestSignInRequest.java
@@ -1,4 +1,9 @@
 package com.lovecloud.auth.presentation.request;
 
-public record GuestSignInRequest() {
+import jakarta.validation.constraints.NotBlank;
+
+public record GuestSignInRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +17,7 @@ public class FundingCreationController {
 
     private final FundingCreationService fundingCreationService;
 
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     @PostMapping("/fundings")
     public ResponseEntity<Long> createFunding(
             @Valid @RequestBody CreateFundingRequest request

--- a/src/main/java/com/lovecloud/global/config/MyController.java
+++ b/src/main/java/com/lovecloud/global/config/MyController.java
@@ -1,0 +1,26 @@
+package com.lovecloud.global.config;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class MyController {
+
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    @GetMapping("/wedding-user")
+    public ResponseEntity<String> weddingUserEndpoint() {
+        return ResponseEntity.ok("WeddingUser Access");
+    }
+
+    @PreAuthorize("hasRole('ROLE_GUEST')")
+    @PostMapping("/guest")
+    public ResponseEntity<String> guestEndpoint() {
+        return ResponseEntity.ok("Guest Access");
+    }
+}
+

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -32,9 +32,6 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/auth/wedding-user/sign-up",
@@ -73,12 +70,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated())
-
-
-                .exceptionHandling(exception -> exception
-                        .accessDeniedHandler(jwtAccessDeniedHandler) //권한 문제 발생
-                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)) //인증 문제 발생
-
 
 //                .authorizeHttpRequests(auth -> auth
 //                        .anyRequest().permitAll())  // 모든 요청을  허용

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.lovecloud.global.config;
 
 import com.lovecloud.global.crypto.BCryptCustomPasswordEncoder;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
+import com.lovecloud.global.jwt.handler.JwtAccessDeniedHandler;
 import com.lovecloud.global.jwt.JwtAuthenticationFilter;
 import com.lovecloud.global.jwt.JwtAuthenticationProvider;
 import com.lovecloud.global.jwt.JwtTokenProvider;
+import com.lovecloud.global.jwt.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +31,9 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
     private static final String[] PUBLIC_ENDPOINTS = {
             "/auth/wedding-user/sign-up",
             "/auth/wedding-user/sign-in",
@@ -67,8 +72,13 @@ public class SecurityConfig {
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated())
 
+                .exceptionHandling(exception -> exception
+                        .accessDeniedHandler(jwtAccessDeniedHandler) //권한 문제 발생
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)) //인증 문제 발생
+
+
 //                .authorizeHttpRequests(auth -> auth
-//                        .anyRequest().permitAll())  // 모든 요청을 허용
+//                        .anyRequest().permitAll())  // 모든 요청을  허용
 
                 .addFilterBefore(jwtAuthenticationFilter(authenticationManager(httpSecurity)),
                     UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
@@ -33,6 +34,7 @@ public class SecurityConfig {
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/auth/wedding-user/sign-up",
@@ -72,6 +74,7 @@ public class SecurityConfig {
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated())
 
+
                 .exceptionHandling(exception -> exception
                         .accessDeniedHandler(jwtAccessDeniedHandler) //권한 문제 발생
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)) //인증 문제 발생
@@ -82,6 +85,7 @@ public class SecurityConfig {
 
                 .addFilterBefore(jwtAuthenticationFilter(authenticationManager(httpSecurity)),
                     UsernamePasswordAuthenticationFilter.class);
+
 
 
     }

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -22,15 +23,19 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
-//    private static final String[] PUBLIC_ENDPOINTS = {
-//            "/auth/wedding-user/sign-up",
-//            "/auth/wedding-user/sign-in",
-//    };
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/auth/wedding-user/sign-up",
+            "/auth/wedding-user/sign-in",
+            "/auth/guest/sign-up",
+            "/auth/guest/sign-in",
+
+    };
 
 
     @Bean
@@ -58,12 +63,12 @@ public class SecurityConfig {
 
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-//                        .anyRequest().authenticated())
-
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll())  // 모든 요청을 허용
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated())
+
+//                .authorizeHttpRequests(auth -> auth
+//                        .anyRequest().permitAll())  // 모든 요청을 허용
 
                 .addFilterBefore(jwtAuthenticationFilter(authenticationManager(httpSecurity)),
                     UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -25,7 +25,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/lovecloud/global/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/lovecloud/global/exception/ExceptionControllerAdvice.java
@@ -24,4 +24,14 @@ public class ExceptionControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.internalServerError()
                 .body(ErrorCode.INTERNAL_SERVER_ERROR_CODE);
     }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorCode> handleRuntimeException(RuntimeException e) {
+        log.error("런타임 예외 발생", e);
+
+        ErrorCode errorCode = SpringSecurityErrorCode.getErrorCode(e);
+
+        return ResponseEntity.status(errorCode.status())
+                .body(errorCode);
+    }
 }

--- a/src/main/java/com/lovecloud/global/exception/SpringSecurityErrorCode.java
+++ b/src/main/java/com/lovecloud/global/exception/SpringSecurityErrorCode.java
@@ -1,0 +1,30 @@
+package com.lovecloud.global.exception;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public enum SpringSecurityErrorCode {
+
+    ACCESS_DENIED(AccessDeniedException.class, 403, "권한이 없는 사용자"),
+    UNAUTHORIZED(AuthenticationException.class, 401, "인증되지 않은 사용자"),
+
+    ETC(RuntimeException.class, 500, "서버에서 알 수 없는 오류가 발생했습니다.");
+
+    private final Class<? extends RuntimeException> exceptionClass;
+    private final int statusCode;
+    private final String message;
+
+    public static ErrorCode getErrorCode(RuntimeException springException) {
+        return Arrays.stream(values())
+                .filter(e -> e.exceptionClass.isAssignableFrom(springException.getClass()))
+                .findAny()
+                .map(e -> new ErrorCode(HttpStatus.valueOf(e.statusCode), e.message))
+                .orElse(new ErrorCode(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationFilter.java
@@ -46,6 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
             Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            log.debug("Authenticated: {}", authentication);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         log.debug("Token is invalid");

--- a/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtAuthenticationProvider.java
@@ -2,6 +2,7 @@ package com.lovecloud.global.jwt;
 
 import com.lovecloud.global.usermanager.JpaUserDetailsService;
 import com.lovecloud.global.usermanager.SecurityUser;
+import com.lovecloud.usermanagement.domain.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,7 +22,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         String token = (String) authentication.getCredentials();
         if (jwtTokenProvider.validateToken(token)) {
             String username = jwtTokenProvider.getUsername(token);
-            SecurityUser userDetails = userDetailsService.loadUserByUsername(username);
+            UserRole userRole = jwtTokenProvider.getUserRole(token);
+            SecurityUser userDetails = userDetailsService.loadUserByUsernameAndRole(username, userRole);
             return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
         }
         return null;

--- a/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import com.lovecloud.global.jwt.exception.*;
 import com.lovecloud.global.jwt.refresh.RefreshToken;
 import com.lovecloud.global.jwt.refresh.RefreshTokenRepository;
 import com.lovecloud.global.usermanager.JpaUserDetailsService;
+import com.lovecloud.usermanagement.domain.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -67,16 +68,20 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
+
     /**
      * AccessToken을 발급하는 메서드
      *
-     * @param username AccessToken을 발급받을 사용자의 ID
+     * @param username AccessToken을 발급받을 사용자의 email
+     * @param userRole AccessToken을 발급받을 사용자의 역할 (UserRole)
      * @return 생성된 AccessToken 문자열
      */
-    public String createAccessToken(String username) {
+    public String createAccessToken(String username, UserRole userRole) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("userRole", userRole);
 
         return Jwts.builder()
-                .setSubject(username)
+                .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + tokenExpirationTime))
@@ -128,14 +133,18 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 주어진 사용자 이름을 기반으로 RefreshToken을 생성하는 메서드
+     * 주어진 email과 UserRole 기반으로 RefreshToken을 생성하는 메서드
      *
-     * @param username RefreshToken을 발급받을 사용자의 이름
+     * @param username RefreshToken을 발급받을 사용자의 email
+     * @param userRole RefreshToken을 발급받을 사용자의 역할 (UserRole)
      * @return 생성된 Refresh Token 문자열
      */
-    public String createRefreshToken(String username) {
+    public String createRefreshToken(String username, UserRole userRole) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("userRole", userRole);
+
         return Jwts.builder()
-                .setSubject(username)
+                .setClaims(claims)
                 .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(Date.from(Instant.now().plus(14, ChronoUnit.DAYS)))

--- a/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
@@ -112,7 +112,7 @@ public class JwtTokenProvider {
      */
     public Authentication getAuthentication(String token) {
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUsername(token));
+        UserDetails userDetails = userDetailsService.loadUserByUsernameAndRole(this.getUsername(token), this.getUserRole(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "",
                 userDetails.getAuthorities());
     }

--- a/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/lovecloud/global/jwt/JwtTokenProvider.java
@@ -180,7 +180,7 @@ public class JwtTokenProvider {
         String username = getUsername(refreshToken);
         UserRole userRole = getUserRole(refreshToken);
 
-        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUsername(username, userRole);
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUsernameAndUserRole(username, userRole);
 
         if (existingToken.isPresent()) {
             String existRefreshToken = existingToken.get().getRefreshToken();

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,9 +1,8 @@
 package com.lovecloud.global.jwt.handler;
 
-import jakarta.servlet.ServletException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.lovecloud.global.jwt.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json");
+
+        String jsonResponse = "{\"message\": \"권한이 없는 사용자\"}";
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAccessDeniedHandler.java
@@ -3,12 +3,14 @@ package com.lovecloud.global.jwt.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
@@ -17,6 +19,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
 
+        log.error("Access Denied: {}", accessDeniedException.getMessage());
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setCharacterEncoding("utf-8");
         response.setContentType("application/json");

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,6 @@
 package com.lovecloud.global.jwt.handler;
 
-import jakarta.servlet.ServletException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.lovecloud.global.jwt.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException{
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json");
+
+        String jsonResponse = "{\"message\": \"인증되지 않은 사용자\"}";
+        response.getWriter().write(jsonResponse);
+
+    }
+}

--- a/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/lovecloud/global/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -3,12 +3,14 @@ package com.lovecloud.global.jwt.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
@@ -17,6 +19,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException{
 
+        log.error("Authentication Failed: {}", authException.getMessage());
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setCharacterEncoding("utf-8");
         response.setContentType("application/json");

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshToken.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.lovecloud.global.jwt.refresh;
 
+import com.lovecloud.usermanagement.domain.UserRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,14 +20,19 @@ public class RefreshToken {
     @Column(nullable = false, length = 60)
     private String username;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole userRole;
+
     @Column(nullable = false)
     private String refreshToken;
 
     @Builder
-    public RefreshToken(Long id, String refreshToken, String username) {
+    public RefreshToken(Long id, String refreshToken, String username, UserRole userRole) {
         this.id = id;
         this.refreshToken = refreshToken;
         this.username = username;
+        this.userRole = userRole;
     }
 }
 

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenRepository.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package com.lovecloud.global.jwt.refresh;
 
+import com.lovecloud.usermanagement.domain.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
 
 
-    Optional<RefreshToken> findByUsername(String email);
+    Optional<RefreshToken> findByUsernameAndUserRole(String email, UserRole userRole);
 
-    void deleteByUsername(String email);
+    void deleteByUsernameAndUserRole(String email, UserRole userRole);
 }

--- a/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenService.java
+++ b/src/main/java/com/lovecloud/global/jwt/refresh/RefreshTokenService.java
@@ -1,12 +1,13 @@
 package com.lovecloud.global.jwt.refresh;
 
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
+import com.lovecloud.usermanagement.domain.UserRole;
 
 public interface RefreshTokenService {
 
-    void createRefreshToken(JwtTokenDto jwtTokenDto, String username);
+    void createRefreshToken(JwtTokenDto jwtTokenDto, String username, UserRole userRole);
 
-    void deleteRefreshToken(JwtTokenDto jwtTokenDto, String username);
+    void deleteRefreshToken(JwtTokenDto jwtTokenDto, String username, UserRole userRole);
 
     String reCreateAccessTokenByRefreshToken(String refreshToken);
 

--- a/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
+++ b/src/main/java/com/lovecloud/global/usermanager/JpaUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.lovecloud.global.usermanager;
 
 import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.domain.UserRole;
 import com.lovecloud.usermanagement.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -21,6 +22,16 @@ public class JpaUserDetailsService implements UserDetailsService {
         Optional<User> user = userRepository.findByEmail(email);
 
         if(user.isPresent()) {
+            return new SecurityUser(user.get());
+        } else {
+            throw new UsernameNotFoundException("User not found");
+        }
+    }
+
+    public SecurityUser loadUserByUsernameAndRole(String email, UserRole userRole) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findByEmailAndUserRole(email, userRole);
+
+        if (user.isPresent()) {
             return new SecurityUser(user.get());
         } else {
             throw new UsernameNotFoundException("User not found");

--- a/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
+++ b/src/main/java/com/lovecloud/global/usermanager/SecurityUser.java
@@ -1,6 +1,7 @@
 package com.lovecloud.global.usermanager;
 
 import com.lovecloud.usermanagement.domain.User;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@Slf4j
 public class SecurityUser implements UserDetails {
 
     private final User user;
@@ -19,7 +21,7 @@ public class SecurityUser implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
 
         List<GrantedAuthority> authorities = new ArrayList<>(2);
-        authorities.add(new SimpleGrantedAuthority(user.getUserRole().name()));
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
 
         return authorities;
     }

--- a/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
@@ -2,6 +2,7 @@ package com.lovecloud.usermanagement.domain;
 
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
+import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -37,5 +38,9 @@ public class Guest extends User {
 
     public String getPassword() {
         return password.getEncryptedPassword();
+    }
+
+    public void signIn(String rawPassword, CustomPasswordEncoder passwordEncoder){
+        this.password.validatePassword(rawPassword, passwordEncoder);
     }
 }

--- a/src/main/java/com/lovecloud/usermanagement/domain/repository/UserRepository.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.lovecloud.usermanagement.domain.repository;
 
 import com.lovecloud.usermanagement.domain.User;
+import com.lovecloud.usermanagement.domain.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndUserRole(String email, UserRole userRole);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #103 
closed #104 
closed #105 

## 💗 작업 동기


## 🛠️ 작업 내용
- [x] SpringSecurityErrorCode enum 작성
- [x] ExceptionControllerAdvice에 런타임 예외 추가
- [x] MyController 삭제
- [x] SecurityConfig에 jwtAccessDeniedHandler, jwtAutenticationEntryPoint 삭제

## 🎯 리뷰 포인트
- 단어 정리

1. @MethodSecurity :  메소드 단위에서 보안 검사를 수행하는 Spring Security의 기능 (@PreAuthorize, @Secured)
2. AOP : 모듈화 프로그래밍 패러다임. 메서드 호출, 예외 발생, 메서드 실행 전후 등의 시점에 특정 기능을 삽입할 수 있다.
3. @ControllerAdvice : Spring MVC에서 전역적으로 예외를 처리하고 특정 행동을 수행할 수 있게한다. (@ExceptionHandler)



- 문제 상황

1. @MethodSecurity는 AOP를 이용하여 권한체크를 하며 이는 Spring MVC 계층까지 전파된다.
2. 하지만 이때 권한 에러가 발생하면 @ControllerAdvice에서 에러를 잡고 응답을 내리기 때문에 SecurityFilterChain에서 AccessDeniedExcption등이 발생하는지 인지하지 못하고 @ControllerAdvice의 로직이 실행된다.

- 왜 이런방식으로 해결했는가?

1. Spring Security 깃허브 이슈와 stackOverflow를 찾아본 결과 ExceptionHandler에서 SpringSecurity 관련 예외를 발견하고 다시 던지는것이 유일한 해결 방법이라고 하였습니다.

4. Spring Security의 모든 예외는 RuntimeException을 상속 받고 있습니다. 따라서 ExceptionControllerAdvice에 RuntimeException만 따로 빼내어 예외 처리하도록 구현하였습니다.


## ✅ 테스트 결과
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/103185987/a28f81aa-a6a2-45e5-b92d-163337644302)
