### PR TITLE
refactor: 양방향 매핑 및 연관관계 관리, 펀딩 목록/상세 조회에 참여자 수 포함 기능 추가

### DIFF
--- a/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
@@ -5,6 +5,8 @@ import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.exception.NotFoundGuestFundingException;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,6 +14,12 @@ public interface GuestFundingRepository extends JpaRepository<GuestFunding, Long
 
     List<GuestFunding> findByFundingIdAndParticipationStatus(Long fundingId,
             ParticipationStatus participationStatus);
+
+    @Query("SELECT COUNT(gf) FROM GuestFunding gf WHERE gf.funding.id = :fundingId AND gf.participationStatus = :status")
+    int countByFundingIdAndParticipationStatus(
+            @Param("fundingId") Long fundingId,
+            @Param("status") ParticipationStatus status
+    );
 
     default GuestFunding findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundGuestFundingException::new);

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
@@ -20,7 +20,7 @@ public class FundingCreationController {
     public ResponseEntity<Long> createFunding(
             @Valid @RequestBody CreateFundingRequest request
     ) {
-        Long memberId = 1L; // TODO: memberId는 @Auth로 받는다고 가정
+        Long memberId = 3L; // TODO: memberId는 @Auth로 받는다고 가정
         final Long fundingId = fundingCreationService.createFunding(request.toCommand(memberId));
         return ResponseEntity.created(URI.create("/fundings/" + fundingId)).build();
     }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationController.java
@@ -26,7 +26,7 @@ public class FundingParticipationController {
             @PathVariable Long fundingId,
             @Valid @RequestBody ParticipateFundingRequest request
     ) {
-        Long memberId = 3L; // TODO: memberId는 @Auth로 받는다고 가정
+        Long memberId = 5L; // TODO: memberId는 @Auth로 받는다고 가정
         ParticipateFundingResponse response = fundingParticipationService.participateInFunding(
                 request.toCommand(fundingId, memberId));
         return ResponseEntity.ok(response);

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
@@ -13,6 +13,7 @@ public record FundingDetailResponse(
         long currentAmount,
         FundingStatus status,
         LocalDateTime endDate,
+        int participantCount,
         ProductOptionsSummary productOptions,
         CoupleSummary couple
 ) {

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
@@ -8,10 +8,9 @@ import java.util.stream.Collectors;
 
 public class FundingDetailResponseMapper {
 
-    public static FundingDetailResponse mapFundingToFundingDetailResponse(Funding funding,
-            List<MainImage> mainImages) {
+    public static FundingDetailResponse map(Funding funding, int participantCount) {
         FundingDetailResponse.ProductOptionsSummary productOptionsSummary = mapToProductOptionsSummary(
-                funding.getProductOptions().getId(), mainImages);
+                funding.getProductOptions().getId(), funding.getProductOptions().getMainImages());
 
         FundingDetailResponse.CoupleSummary coupleSummary = mapToCoupleSummary(funding);
 
@@ -23,6 +22,7 @@ public class FundingDetailResponseMapper {
                 funding.getCurrentAmount(),
                 funding.getStatus(),
                 funding.getEndDate(),
+                participantCount,
                 productOptionsSummary,
                 coupleSummary
         );

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponse.java
@@ -11,8 +11,8 @@ public record FundingListResponse(
         long currentAmount,
         FundingStatus status,
         LocalDateTime endDate,
-        ProductOptionsSummary productOptions,
-        CoupleSummary couple
+        int participantCount,
+        ProductOptionsSummary productOptions
 ) {
 
     public static record ProductOptionsSummary(
@@ -26,11 +26,5 @@ public record FundingListResponse(
         ) {
 
         }
-    }
-
-    public static record CoupleSummary(
-            Long coupleId
-    ) {
-
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponseMapper.java
@@ -1,24 +1,18 @@
 package com.lovecloud.fundingmanagement.query.response;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
-import com.lovecloud.productmanagement.domain.MainImage;
-import java.util.List;
 import java.util.stream.Collectors;
+
 
 public class FundingListResponseMapper {
 
-    public static FundingListResponse mapFundingToFundingListResponse(Funding funding,
-            List<MainImage> mainImages) {
+    public static FundingListResponse map(Funding funding, int participantCount) {
         FundingListResponse.ProductOptionsSummary productOptionsSummary = new FundingListResponse.ProductOptionsSummary(
                 funding.getProductOptions().getId(),
-                mainImages.stream()
+                funding.getProductOptions().getMainImages().stream()
                         .map(image -> new FundingListResponse.ProductOptionsSummary.ImageData(
                                 image.getId(), image.getMainImageName()))
                         .collect(Collectors.toList())
-        );
-
-        FundingListResponse.CoupleSummary coupleSummary = new FundingListResponse.CoupleSummary(
-                funding.getCouple().getId()
         );
 
         return new FundingListResponse(
@@ -28,8 +22,8 @@ public class FundingListResponseMapper {
                 funding.getCurrentAmount(),
                 funding.getStatus(),
                 funding.getEndDate(),
-                productOptionsSummary,
-                coupleSummary
+                participantCount,
+                productOptionsSummary
         );
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
@@ -4,7 +4,7 @@ import com.lovecloud.fundingmanagement.domain.GuestFunding;
 
 public class GuestFundingListResponseMapper {
 
-    public static GuestFundingListResponse mapGuestFundingToGuestFundingListResponse(
+    public static GuestFundingListResponse map(
             GuestFunding guestFunding) {
         return new GuestFundingListResponse(
                 guestFunding.getId(),

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
@@ -20,8 +20,11 @@ public class ProductOptionsCreationService {
     public Long addProductOptions(CreateProductOptionsCommand command) {
         Product product = productRepository.findByIdOrThrow(command.productId());
         ProductOptions options = command.toProductOptions(product);
+        product.addProductOptions(options);
         command.toMainImages(options).forEach(options::addMainImage);
         command.toDescriptionImages(options).forEach(options::addDescriptionImage);
-        return productOptionsRepository.save(options).getId();
+        ProductOptions savedOptions = productOptionsRepository.save(options);
+        productRepository.save(product);
+        return savedOptions.getId();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
@@ -1,15 +1,10 @@
 package com.lovecloud.productmanagement.application;
 
 import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
-import com.lovecloud.productmanagement.domain.DescriptionImage;
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,21 +16,12 @@ public class ProductOptionsCreationService {
 
     private final ProductRepository productRepository;
     private final ProductOptionsRepository productOptionsRepository;
-    private final MainImageRepository mainImageRepository;
-    private final DescriptionImageRepository descriptionImagesRepository;
 
     public Long addProductOptions(CreateProductOptionsCommand command) {
         Product product = productRepository.findByIdOrThrow(command.productId());
         ProductOptions options = command.toProductOptions(product);
-        options = productOptionsRepository.save(options);
-        createAndSaveImages(command, options);
-        return options.getId();
-    }
-
-    private void createAndSaveImages(CreateProductOptionsCommand command, ProductOptions options) {
-        List<MainImage> mainImages = command.toMainImages(options);
-        mainImageRepository.saveAll(mainImages);
-        List<DescriptionImage> descriptionImages = command.toDescriptionImages(options);
-        descriptionImagesRepository.saveAll(descriptionImages);
+        command.toMainImages(options).forEach(options::addMainImage);
+        command.toDescriptionImages(options).forEach(options::addDescriptionImage);
+        return productOptionsRepository.save(options).getId();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
@@ -1,11 +1,7 @@
 package com.lovecloud.productmanagement.application;
 
-import com.lovecloud.productmanagement.domain.DescriptionImage;
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
 import com.lovecloud.productmanagement.query.response.ProductDetailResponse;
@@ -25,41 +21,21 @@ public class ProductQueryService {
 
     private final ProductRepository productRepository;
     private final ProductOptionsRepository productOptionsRepository;
-    private final MainImageRepository mainImageRepository;
-    private final DescriptionImageRepository descriptionImageRepository;
 
     public List<ProductListResponse> findAllByCategoryId(Long categoryId) {
         List<Product> products = categoryId == null
                 ? productRepository.findAll()
                 : productRepository.findByCategoryId(categoryId);
         return products.stream()
-                .map(this::mapProductToProductListResponse)
+                .map(ProductListResponseMapper::map)
                 .collect(Collectors.toList());
     }
 
     public ProductDetailResponse findById(Long productOptionsId) {
         ProductOptions selectedOption = productOptionsRepository.findByIdAndIsDeletedOrThrow(
                 productOptionsId, false);
-        List<MainImage> mainImages = mainImageRepository.findByProductOptionsId(
-                selectedOption.getId());
-        List<DescriptionImage> descriptionImages = descriptionImageRepository.findByProductOptionsId(
-                selectedOption.getId());
         List<ProductOptions> otherOptions = productOptionsRepository.findOthersByProductId(
                 selectedOption.getProduct().getId(), selectedOption.getId());
-        return ProductDetailResponseMapper.mapProductOptionsToProductDetailResponse(selectedOption,
-                mainImages, descriptionImages, otherOptions);
-    }
-
-    private ProductListResponse mapProductToProductListResponse(Product product) {
-        List<ProductOptions> validOptions = productOptionsRepository
-                .findByProductIdAndIsDeleted(product.getId(), false);
-        if (validOptions.isEmpty()) {
-            return null;
-        }
-        return ProductListResponseMapper.mapProductToProductListResponse(
-                product,
-                validOptions,
-                mainImageRepository
-        );
+        return ProductDetailResponseMapper.map(selectedOption, otherOptions);
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
@@ -30,14 +30,19 @@ public record CreateProductOptionsCommand(
 
     public List<MainImage> toMainImages(ProductOptions productOptions) {
         return mainImageNames.stream()
-                .map(mainImageName -> MainImage.createMainImage(mainImageName, productOptions))
+                .map(mainImageName -> MainImage.builder()
+                        .mainImageName(mainImageName)
+                        .productOptions(productOptions)
+                        .build())
                 .toList();
     }
 
     public List<DescriptionImage> toDescriptionImages(ProductOptions productOptions) {
         return descriptionImageNames.stream()
-                .map(descriptionImageName -> DescriptionImage.createDescriptionImage(
-                        descriptionImageName, productOptions))
+                .map(descriptionImageName -> DescriptionImage.builder()
+                        .descriptionImageName(descriptionImageName)
+                        .productOptions(productOptions)
+                        .build())
                 .toList();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
@@ -30,19 +30,14 @@ public record CreateProductOptionsCommand(
 
     public List<MainImage> toMainImages(ProductOptions productOptions) {
         return mainImageNames.stream()
-                .map(mainImageName -> MainImage.builder()
-                        .productOptions(productOptions)
-                        .mainImageName(mainImageName)
-                        .build())
+                .map(mainImageName -> MainImage.createMainImage(mainImageName, productOptions))
                 .toList();
     }
 
     public List<DescriptionImage> toDescriptionImages(ProductOptions productOptions) {
         return descriptionImageNames.stream()
-                .map(descriptionImageName -> DescriptionImage.builder()
-                        .productOptions(productOptions)
-                        .descriptionImageName(descriptionImageName)
-                        .build())
+                .map(descriptionImageName -> DescriptionImage.createDescriptionImage(
+                        descriptionImageName, productOptions))
                 .toList();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
@@ -38,4 +38,18 @@ public class DescriptionImage extends CommonRootEntity<Long> {
         this.descriptionImageName = descriptionImageName;
         this.productOptions = productOptions;
     }
+
+    public static DescriptionImage createDescriptionImage(String descriptionImageName, ProductOptions productOptions) {
+        return DescriptionImage.builder()
+                .descriptionImageName(descriptionImageName)
+                .productOptions(productOptions)
+                .build();
+    }
+
+    public void setProductOptions(ProductOptions productOptions) {
+        this.productOptions = productOptions;
+        if (!productOptions.getDescriptionImages().contains(this)) {
+            productOptions.getDescriptionImages().add(this);
+        }
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
@@ -39,13 +39,6 @@ public class DescriptionImage extends CommonRootEntity<Long> {
         this.productOptions = productOptions;
     }
 
-    public static DescriptionImage createDescriptionImage(String descriptionImageName, ProductOptions productOptions) {
-        return DescriptionImage.builder()
-                .descriptionImageName(descriptionImageName)
-                .productOptions(productOptions)
-                .build();
-    }
-
     public void setProductOptions(ProductOptions productOptions) {
         this.productOptions = productOptions;
         if (!productOptions.getDescriptionImages().contains(this)) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
@@ -38,4 +38,18 @@ public class MainImage extends CommonRootEntity<Long> {
         this.mainImageName = mainImageName;
         this.productOptions = productOptions;
     }
+
+    public static MainImage createMainImage(String mainImageName, ProductOptions productOptions) {
+        return MainImage.builder()
+                .mainImageName(mainImageName)
+                .productOptions(productOptions)
+                .build();
+    }
+
+    public void setProductOptions(ProductOptions productOptions) {
+        this.productOptions = productOptions;
+        if (!productOptions.getMainImages().contains(this)) {
+            productOptions.getMainImages().add(this);
+        }
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
@@ -39,13 +39,6 @@ public class MainImage extends CommonRootEntity<Long> {
         this.productOptions = productOptions;
     }
 
-    public static MainImage createMainImage(String mainImageName, ProductOptions productOptions) {
-        return MainImage.builder()
-                .mainImageName(mainImageName)
-                .productOptions(productOptions)
-                .build();
-    }
-
     public void setProductOptions(ProductOptions productOptions) {
         this.productOptions = productOptions;
         if (!productOptions.getMainImages().contains(this)) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/Product.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/Product.java
@@ -1,6 +1,7 @@
 package com.lovecloud.productmanagement.domain;
 
 import com.lovecloud.global.domain.CommonRootEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,7 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,9 +37,19 @@ public class Product extends CommonRootEntity<Long> {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ProductOptions> productOptions = new ArrayList<>();
+
     @Builder
     public Product(String productName, Category category) {
         this.productName = productName;
         this.category = category;
+    }
+
+    public void addProductOptions(ProductOptions productOption) {
+        productOptions.add(productOption);
+        if (productOption.getProduct() != this) {
+            productOption.setProduct(this);
+        }
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -56,6 +56,13 @@ public class ProductOptions extends CommonRootEntity<Long> {
         this.product = product;
     }
 
+    public void setProduct(Product product) {
+        this.product = product;
+        if (!product.getProductOptions().contains(this)) {
+            product.getProductOptions().add(this);
+        }
+    }
+
     public void addMainImage(MainImage mainImage) {
         mainImages.add(mainImage);
         if (mainImage.getProductOptions() != this) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -42,6 +42,9 @@ public class ProductOptions extends CommonRootEntity<Long> {
     @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
     private List<MainImage> mainImages;
 
+    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
+    private List<DescriptionImage> descriptionImages;
+
     @Builder
     public ProductOptions(String color, String modelName, Long price, Integer stockQuantity,
             Product product) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -2,6 +2,7 @@ package com.lovecloud.productmanagement.domain;
 
 import com.lovecloud.global.domain.CommonRootEntity;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,11 +40,11 @@ public class ProductOptions extends CommonRootEntity<Long> {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
-    private List<MainImage> mainImages;
+    @OneToMany(mappedBy = "productOptions", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MainImage> mainImages = new ArrayList<>();
 
-    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
-    private List<DescriptionImage> descriptionImages;
+    @OneToMany(mappedBy = "productOptions", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<DescriptionImage> descriptionImages = new ArrayList<>();
 
     @Builder
     public ProductOptions(String color, String modelName, Long price, Integer stockQuantity,
@@ -53,5 +54,19 @@ public class ProductOptions extends CommonRootEntity<Long> {
         this.price = price;
         this.stockQuantity = stockQuantity;
         this.product = product;
+    }
+
+    public void addMainImage(MainImage mainImage) {
+        mainImages.add(mainImage);
+        if (mainImage.getProductOptions() != this) {
+            mainImage.setProductOptions(this);
+        }
+    }
+
+    public void addDescriptionImage(DescriptionImage descriptionImage) {
+        descriptionImages.add(descriptionImage);
+        if (descriptionImage.getProductOptions() != this) {
+            descriptionImage.setProductOptions(this);
+        }
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponse.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponse.java
@@ -5,17 +5,9 @@ import java.util.List;
 public record ProductDetailResponse(
         Long productId,
         String productName,
-        CategoryData category,
         ProductOptionDetail selectedOption,
         List<OtherOptionData> otherOptions
 ) {
-
-    public static record CategoryData(
-            Long categoryId,
-            String categoryName
-    ) {
-
-    }
 
     public static record ProductOptionDetail(
             Long productOptionsId,
@@ -26,20 +18,18 @@ public record ProductDetailResponse(
             List<ImageData> mainImages,
             List<ImageData> descriptionImages
     ) {
+        public static record ImageData(
+                Long imageId,
+                String imageName
+        ) {
 
+        }
     }
 
     public static record OtherOptionData(
             Long productOptionsId,
             String color,
             int stockQuantity
-    ) {
-
-    }
-
-    public static record ImageData(
-            Long imageId,
-            String imageName
     ) {
 
     }

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponseMapper.java
@@ -10,62 +10,48 @@ import java.util.stream.Collectors;
 
 public class ProductDetailResponseMapper {
 
-    public static ProductDetailResponse mapProductOptionsToProductDetailResponse(
-            ProductOptions selectedOption,
-            List<MainImage> mainImages,
-            List<DescriptionImage> descriptionImages,
-            List<ProductOptions> otherOptions
-    ) {
+    public static ProductDetailResponse map(ProductOptions selectedOption, List<ProductOptions> otherOptions) {
         return new ProductDetailResponse(
                 selectedOption.getProduct().getId(),
                 selectedOption.getProduct().getProductName(),
-                new ProductDetailResponse.CategoryData(
-                        selectedOption.getProduct().getCategory().getId(),
-                        selectedOption.getProduct().getCategory().getCategoryName()
-                ),
-                mapSelectedOptionDetail(selectedOption, mainImages, descriptionImages),
+                mapSelectedOptionDetail(selectedOption),
                 mapOtherOptions(otherOptions)
         );
     }
 
-    private static ProductOptionDetail mapSelectedOptionDetail(
-            ProductOptions option,
-            List<MainImage> mainImages,
-            List<DescriptionImage> descriptionImages
-    ) {
-        return new ProductDetailResponse.ProductOptionDetail(
+    private static ProductOptionDetail mapSelectedOptionDetail(ProductOptions option) {
+        return new ProductOptionDetail(
                 option.getId(),
                 option.getColor(),
                 option.getModelName(),
                 option.getPrice(),
                 option.getStockQuantity(),
-                mapMainImages(mainImages),
-                mapDescriptionImages(descriptionImages)
+                mapMainImages(option.getMainImages()),
+                mapDescriptionImages(option.getDescriptionImages())
         );
     }
 
     private static List<OtherOptionData> mapOtherOptions(List<ProductOptions> otherOptions) {
         return otherOptions.stream()
-                .map(option -> new ProductDetailResponse.OtherOptionData(
+                .map(option -> new OtherOptionData(
                         option.getId(),
                         option.getColor(),
                         option.getStockQuantity()))
                 .collect(Collectors.toList());
     }
 
-    private static List<ProductDetailResponse.ImageData> mapMainImages(List<MainImage> images) {
+    private static List<ProductOptionDetail.ImageData> mapMainImages(List<MainImage> images) {
         return images.stream()
-                .map(image -> new ProductDetailResponse.ImageData(
+                .map(image -> new ProductOptionDetail.ImageData(
                         image.getId(),
                         image.getMainImageName()
                 ))
                 .collect(Collectors.toList());
     }
 
-    private static List<ProductDetailResponse.ImageData> mapDescriptionImages(
-            List<DescriptionImage> images) {
+    private static List<ProductOptionDetail.ImageData> mapDescriptionImages(List<DescriptionImage> images) {
         return images.stream()
-                .map(image -> new ProductDetailResponse.ImageData(
+                .map(image -> new ProductOptionDetail.ImageData(
                         image.getId(),
                         image.getDescriptionImageName()
                 ))

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponse.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponse.java
@@ -8,13 +8,6 @@ public record ProductListResponse(
         List<ProductOptionSummary> options
 ) {
 
-    public static record CategoryData(
-            Long categoryId,
-            String categoryName
-    ) {
-
-    }
-
     public static record ProductOptionSummary(
             Long productOptionsId,
             String color,

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponseMapper.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponseMapper.java
@@ -1,22 +1,18 @@
 package com.lovecloud.productmanagement.query.response;
 
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
 
 public class ProductListResponseMapper {
 
-    public static ProductListResponse mapProductToProductListResponse(
-            Product product,
-            List<ProductOptions> options,
-            MainImageRepository mainImageRepository
-    ) {
-        List<ProductListResponse.ProductOptionSummary> optionSummaries = options.stream()
-                .map(option -> mapProductOptionToProductOptionSummary(option, mainImageRepository))
+    public static ProductListResponse map(Product product) {
+        List<ProductListResponse.ProductOptionSummary> optionSummaries = product.getProductOptions()
+                .stream()
+                .filter(option -> !option.getIsDeleted())
+                .map(ProductListResponseMapper::mapProductOptionToProductOptionSummary)
                 .collect(Collectors.toList());
 
         return new ProductListResponse(
@@ -27,11 +23,9 @@ public class ProductListResponseMapper {
     }
 
     private static ProductListResponse.ProductOptionSummary mapProductOptionToProductOptionSummary(
-            ProductOptions option,
-            MainImageRepository mainImageRepository
-    ) {
-        List<MainImage> mainImages = mainImageRepository.findByProductOptionsId(option.getId());
-        List<ProductListResponse.ProductOptionSummary.ImageData> imageDatas = mainImages.stream()
+            ProductOptions option) {
+        List<ProductListResponse.ProductOptionSummary.ImageData> imageDatas = option.getMainImages()
+                .stream()
                 .map(image -> new ProductListResponse.ProductOptionSummary.ImageData(
                         image.getId(),
                         image.getMainImageName()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #109 
closed #111

## 💗 작업 동기

1. 양방향 매핑 도입
    - ProductOption <-1---N-> MainImage
저희 서비스는 ProductOption을 조회할 때, 대부분의 상황에서 MainImage를 함께 조회합니다. 그래서 ProductOption와 MainImage 엔티티 간의 양방향 연관관계를 설정하였습니다. (#99 참고) 양방향 연관관계를 맺게 되었기 때문에, 데이터 일관성 및 무한 루프 방지를 위한 코드가 필요해졌습니다. 이를 위해 전체적인 코드 리팩터링을 진행하였습니다.

    - ProductOption <-1---N-> DescriptionImage
DescriptionImage도 마찬가지로 동일하게 진행하였습니다.

    - Product <-1---N-> ProductOption
Product도 마찬가지로 동일하게 진행하였습니다.

2. 펀딩 목록/상세 조회 Response에 참여자 수 포함
    - 참여자 수 정보가 필요해서 추가하였습니다. 

## 🛠️ 작업 내용
#### 양방향 필드 추가
- [x] Product 엔티티에 `List<ProductOption>` 필드 추가하여 양방향 연관관계 설정
- [x] ProductOption 엔티티에 `List<MainImage>`, `List<DescriptionImage>` 필드 추가하여 양방향 연관관계 설정
#### 엔티티 JPA 매핑 설정
- [x] @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)을 Product 엔티티의 productOptions 필드에 추가하여 ProductOptions 엔티티와의 연관관계를 설정
- [x] @OneToMany(mappedBy = "productOptions", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)을 ProductOptions 엔티티의 mainImages 및 descriptionImages 필드에 추가하여 MainImage 및 DescriptionImage 엔티티와의 연관관계를 설정
#### 편의 메소드 구현
- [x] Product 엔티티에 addProductOptions 메소드를 추가하여 ProductOptions 엔티티를 Product 엔티티에 추가할 때 양방향 연관관계를 일관되게 유지하도록 구현
- [x] ProductOptions 엔티티에 addMainImage 및 addDescriptionImage 메소드를 추가하여 각각의 엔티티를 ProductOptions 엔티티에 추가할 때 양방향 연관관계를 일관되게 유지하도록 구현
- [x] MainImage 및 DescriptionImage 엔티티에 setProductOptions 메소드를 추가하여 ProductOptions 엔티티와의 양방향 연관관계를 일관되게 유지하도록 구현
#### ProductOptionCreateService 영속성 주의해서 재구현
- [x] ProductOptionsCreationService에서 addProductOptions 메소드를 통해 Product 엔티티에 ProductOptions 엔티티를 추가하고, ProductOptions 엔티티에 MainImage 및 DescriptionImage 엔티티를 추가하도록 수정
- [x] ProductOptionsCreationService의 addProductOptions 메소드에서 ProductOptions 엔티티를 Product 엔티티에 추가한 후 Product 엔티티를 저장하여 모든 연관된 엔티티가 함께 영속화되도록 구현
#### 기타
- [x] 펀딩 목록/상세 조회 Response에 참여자 수 포함

## 🎯 리뷰 포인트

1. 양방향 연관관계 설정이 올바르게 되어 있는지 확인해주세요.
    - Product와 ProductOption 간의 양방향 연관관계
    - ProductOption와 MainImage 및 DescriptionImage 간의 양방향 연관관계

2. 연관관계 편의 메소드(addProductOption, addMainImage, addDescriptionImage, setProductOption 등)를 통해 데이터의 일관성을 유지할 수 있는지 확인해주세요.

3. cascade = CascadeType.ALL 및 orphanRemoval = true 설정이 적절하게 되어있는지 확인해주세요.

4. ProductOptionCreateService에서 Product 엔티티를 저장함으로써 모든 연관된 엔티티 ProductOption, MainImage, DescriptionImage가 올바르게 영속화되는지 확인해주세요.

5. 이외에 양방향 연관관계에 의해 데이터 일관성이나 무한 루프가 발생하지 않는지 확인해주세요.

## ✅ 테스트 결과

1. Product 생성

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/0be37e15-e59e-42ca-be7a-c61f0fa3f88d)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/94b3dc49-9f31-43b2-8703-0d4d12e46d03)

2. ProductOption 생성

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/6603a35c-073b-4cb9-a2bd-f6199407f0cd)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/2b349905-d73a-44f3-b796-200664e9be9f)

MainImage 올바르게 생성됨

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/958f5964-3d5b-4f72-b0f8-b4ce4bfc5829)

DescriptionImage 올바르게 생성됨

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/2f15c34c-6758-45dd-ac2d-048b3c4a4162)

---

3. 펀딩 목록/상세 조회에 참여자 수 포함됨

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/d638426a-32d9-4072-92a3-a5dfdad6316a)

![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/28eb0ce6-3815-4e36-8634-706bfcfa6f1c)




