### PR TITLE
feat: 주문 가능한 펀딩 목록 조회

### DIFF
--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingQueryService.java
@@ -4,13 +4,17 @@ import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
 import com.lovecloud.fundingmanagement.domain.repository.GuestFundingRepository;
+import com.lovecloud.fundingmanagement.query.repository.OrderableFundingRepository;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponseMapper;
 import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponseMapper;
+import com.lovecloud.fundingmanagement.query.response.OrderableFundingResponse;
+import com.lovecloud.fundingmanagement.query.response.OrderableFundingResponseMapper;
 import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
+import com.lovecloud.usermanagement.domain.Couple;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +30,7 @@ public class FundingQueryService {
     private final FundingRepository fundingRepository;
     private final CoupleRepository coupleRepository;
     private final GuestFundingRepository guestFundingRepository;
+    private final OrderableFundingRepository orderableFundingRepository;
 
     public List<FundingListResponse> findAllByCoupleId(Long coupleId) {
         coupleRepository.findByIdOrThrow(coupleId);
@@ -55,5 +60,12 @@ public class FundingQueryService {
                         ParticipationStatus.PAID).stream()
                 .map(GuestFundingListResponseMapper::map)
                 .collect(Collectors.toList());
+    }
+
+    public List<OrderableFundingResponse> findOrderableFundingsByUserId(Long userId) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
+        return orderableFundingRepository.findOrderableFundingsByCoupleId(couple.getId()).stream()
+                .map(OrderableFundingResponseMapper::map)
+                .toList();
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
@@ -5,6 +5,8 @@ import com.lovecloud.fundingmanagement.domain.ParticipationStatus;
 import com.lovecloud.fundingmanagement.exception.NotFoundGuestFundingException;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,6 +14,12 @@ public interface GuestFundingRepository extends JpaRepository<GuestFunding, Long
 
     List<GuestFunding> findByFundingIdAndParticipationStatus(Long fundingId,
             ParticipationStatus participationStatus);
+
+    @Query("SELECT COUNT(gf) FROM GuestFunding gf WHERE gf.funding.id = :fundingId AND gf.participationStatus = :status")
+    int countByFundingIdAndParticipationStatus(
+            @Param("fundingId") Long fundingId,
+            @Param("status") ParticipationStatus status
+    );
 
     default GuestFunding findByIdOrThrow(Long id) {
         return findById(id).orElseThrow(NotFoundGuestFundingException::new);

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCreationController.java
@@ -20,7 +20,7 @@ public class FundingCreationController {
     public ResponseEntity<Long> createFunding(
             @Valid @RequestBody CreateFundingRequest request
     ) {
-        Long memberId = 1L; // TODO: memberId는 @Auth로 받는다고 가정
+        Long memberId = 3L; // TODO: memberId는 @Auth로 받는다고 가정
         final Long fundingId = fundingCreationService.createFunding(request.toCommand(memberId));
         return ResponseEntity.created(URI.create("/fundings/" + fundingId)).build();
     }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationController.java
@@ -26,7 +26,7 @@ public class FundingParticipationController {
             @PathVariable Long fundingId,
             @Valid @RequestBody ParticipateFundingRequest request
     ) {
-        Long memberId = 3L; // TODO: memberId는 @Auth로 받는다고 가정
+        Long memberId = 5L; // TODO: memberId는 @Auth로 받는다고 가정
         ParticipateFundingResponse response = fundingParticipationService.participateInFunding(
                 request.toCommand(fundingId, memberId));
         return ResponseEntity.ok(response);

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -4,6 +4,7 @@ import com.lovecloud.fundingmanagement.application.FundingQueryService;
 import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
+import com.lovecloud.fundingmanagement.query.response.OrderableFundingResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,5 +41,12 @@ public class FundingQueryController {
         final List<GuestFundingListResponse> guestFundings =
                 fundingQueryService.findAllGuestFundingsByFundingId(fundingId);
         return ResponseEntity.ok(guestFundings);
+    }
+
+    @GetMapping("/orderable-fundings")
+    public ResponseEntity<List<OrderableFundingResponse>> listOrderableFundings() {
+        Long memberId = 3L; // TODO: memberId는 @Auth로 받는다고 가정
+        final List<OrderableFundingResponse> orderableFundings = fundingQueryService.findOrderableFundingsByUserId(memberId);
+        return ResponseEntity.ok(orderableFundings);
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/repository/OrderableFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/repository/OrderableFundingRepository.java
@@ -1,0 +1,29 @@
+package com.lovecloud.fundingmanagement.query.repository;
+
+import com.lovecloud.fundingmanagement.domain.Funding;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 주문 가능한 펀딩을 조회하는 리포지토리입니다. 이 리포지토리는 특정 부부의 완료된 펀딩 중에서 아직 주문되지 않았거나 주문이 취소된 펀딩을 조회하는 기능을 제공합니다.
+ */
+@Repository
+public interface OrderableFundingRepository extends JpaRepository<Funding, Long> {
+
+    /**
+     * 특정 부부의 완료된 펀딩 중 주문 가능한 펀딩 목록을 조회합니다. 주문 가능한 펀딩은 펀딩 상태가 'COMPLETED'이며, 관련된 주문이 없거나 주문 상태가
+     * 'CANCEL_COMPLETED'인 펀딩을 의미합니다.
+     *
+     * @param coupleId 부부의 ID
+     * @return 특정 부부의 주문 가능한 펀딩 목록을 반환합니다.
+     */
+    @Query("SELECT f FROM Funding f " +
+            "LEFT JOIN OrderDetails od ON f.id = od.funding.id " +
+            "LEFT JOIN Order o ON od.order.id = o.id " +
+            "WHERE f.couple.id = :coupleId AND f.status = 'COMPLETED' AND " +
+            "(o IS NULL OR o.orderStatus = 'CANCEL_COMPLETED')")
+    List<Funding> findOrderableFundingsByCoupleId(@Param("coupleId") Long coupleId);
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/repository/OrderableFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/repository/OrderableFundingRepository.java
@@ -21,9 +21,8 @@ public interface OrderableFundingRepository extends JpaRepository<Funding, Long>
      * @return 특정 부부의 주문 가능한 펀딩 목록을 반환합니다.
      */
     @Query("SELECT f FROM Funding f " +
-            "LEFT JOIN OrderDetails od ON f.id = od.funding.id " +
-            "LEFT JOIN Order o ON od.order.id = o.id " +
             "WHERE f.couple.id = :coupleId AND f.status = 'COMPLETED' AND " +
-            "(o IS NULL OR o.orderStatus = 'CANCEL_COMPLETED')")
+            "NOT EXISTS (SELECT od FROM OrderDetails od JOIN Order o ON od.order.id = o.id " +
+            "WHERE od.funding.id = f.id AND o.orderStatus <> 'CANCEL_COMPLETED')")
     List<Funding> findOrderableFundingsByCoupleId(@Param("coupleId") Long coupleId);
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponse.java
@@ -13,6 +13,7 @@ public record FundingDetailResponse(
         long currentAmount,
         FundingStatus status,
         LocalDateTime endDate,
+        int participantCount,
         ProductOptionsSummary productOptions,
         CoupleSummary couple
 ) {

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingDetailResponseMapper.java
@@ -8,10 +8,9 @@ import java.util.stream.Collectors;
 
 public class FundingDetailResponseMapper {
 
-    public static FundingDetailResponse mapFundingToFundingDetailResponse(Funding funding,
-            List<MainImage> mainImages) {
+    public static FundingDetailResponse map(Funding funding, int participantCount) {
         FundingDetailResponse.ProductOptionsSummary productOptionsSummary = mapToProductOptionsSummary(
-                funding.getProductOptions().getId(), mainImages);
+                funding.getProductOptions().getId(), funding.getProductOptions().getMainImages());
 
         FundingDetailResponse.CoupleSummary coupleSummary = mapToCoupleSummary(funding);
 
@@ -23,6 +22,7 @@ public class FundingDetailResponseMapper {
                 funding.getCurrentAmount(),
                 funding.getStatus(),
                 funding.getEndDate(),
+                participantCount,
                 productOptionsSummary,
                 coupleSummary
         );

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponse.java
@@ -11,8 +11,8 @@ public record FundingListResponse(
         long currentAmount,
         FundingStatus status,
         LocalDateTime endDate,
-        ProductOptionsSummary productOptions,
-        CoupleSummary couple
+        int participantCount,
+        ProductOptionsSummary productOptions
 ) {
 
     public static record ProductOptionsSummary(
@@ -26,11 +26,5 @@ public record FundingListResponse(
         ) {
 
         }
-    }
-
-    public static record CoupleSummary(
-            Long coupleId
-    ) {
-
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/FundingListResponseMapper.java
@@ -1,24 +1,18 @@
 package com.lovecloud.fundingmanagement.query.response;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
-import com.lovecloud.productmanagement.domain.MainImage;
-import java.util.List;
 import java.util.stream.Collectors;
+
 
 public class FundingListResponseMapper {
 
-    public static FundingListResponse mapFundingToFundingListResponse(Funding funding,
-            List<MainImage> mainImages) {
+    public static FundingListResponse map(Funding funding, int participantCount) {
         FundingListResponse.ProductOptionsSummary productOptionsSummary = new FundingListResponse.ProductOptionsSummary(
                 funding.getProductOptions().getId(),
-                mainImages.stream()
+                funding.getProductOptions().getMainImages().stream()
                         .map(image -> new FundingListResponse.ProductOptionsSummary.ImageData(
                                 image.getId(), image.getMainImageName()))
                         .collect(Collectors.toList())
-        );
-
-        FundingListResponse.CoupleSummary coupleSummary = new FundingListResponse.CoupleSummary(
-                funding.getCouple().getId()
         );
 
         return new FundingListResponse(
@@ -28,8 +22,8 @@ public class FundingListResponseMapper {
                 funding.getCurrentAmount(),
                 funding.getStatus(),
                 funding.getEndDate(),
-                productOptionsSummary,
-                coupleSummary
+                participantCount,
+                productOptionsSummary
         );
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/GuestFundingListResponseMapper.java
@@ -4,7 +4,7 @@ import com.lovecloud.fundingmanagement.domain.GuestFunding;
 
 public class GuestFundingListResponseMapper {
 
-    public static GuestFundingListResponse mapGuestFundingToGuestFundingListResponse(
+    public static GuestFundingListResponse map(
             GuestFunding guestFunding) {
         return new GuestFundingListResponse(
                 guestFunding.getId(),

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/OrderableFundingResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/OrderableFundingResponse.java
@@ -1,0 +1,20 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import java.util.List;
+
+public record OrderableFundingResponse(
+        Long fundingId,
+        long price,
+        Long productOptionId,
+        String productName,
+        String modelName,
+        List<ImageData> mainImages
+) {
+
+    public static record ImageData(
+            Long imageId,
+            String imageName
+    ) {
+
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/OrderableFundingResponseMapper.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/OrderableFundingResponseMapper.java
@@ -1,0 +1,23 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.productmanagement.domain.ProductOptions;
+
+public class OrderableFundingResponseMapper {
+
+    public static OrderableFundingResponse map(Funding funding) {
+        ProductOptions productOptions = funding.getProductOptions();
+        return new OrderableFundingResponse(
+                funding.getId(),
+                funding.getTargetAmount(),
+                productOptions.getId(),
+                productOptions.getProduct().getProductName(),
+                productOptions.getModelName(),
+                productOptions.getMainImages().stream()
+                        .map(image -> new OrderableFundingResponse.ImageData(
+                                image.getId(),
+                                image.getMainImageName()))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
@@ -20,8 +20,11 @@ public class ProductOptionsCreationService {
     public Long addProductOptions(CreateProductOptionsCommand command) {
         Product product = productRepository.findByIdOrThrow(command.productId());
         ProductOptions options = command.toProductOptions(product);
+        product.addProductOptions(options);
         command.toMainImages(options).forEach(options::addMainImage);
         command.toDescriptionImages(options).forEach(options::addDescriptionImage);
-        return productOptionsRepository.save(options).getId();
+        ProductOptions savedOptions = productOptionsRepository.save(options);
+        productRepository.save(product);
+        return savedOptions.getId();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductOptionsCreationService.java
@@ -1,15 +1,10 @@
 package com.lovecloud.productmanagement.application;
 
 import com.lovecloud.productmanagement.application.command.CreateProductOptionsCommand;
-import com.lovecloud.productmanagement.domain.DescriptionImage;
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,21 +16,12 @@ public class ProductOptionsCreationService {
 
     private final ProductRepository productRepository;
     private final ProductOptionsRepository productOptionsRepository;
-    private final MainImageRepository mainImageRepository;
-    private final DescriptionImageRepository descriptionImagesRepository;
 
     public Long addProductOptions(CreateProductOptionsCommand command) {
         Product product = productRepository.findByIdOrThrow(command.productId());
         ProductOptions options = command.toProductOptions(product);
-        options = productOptionsRepository.save(options);
-        createAndSaveImages(command, options);
-        return options.getId();
-    }
-
-    private void createAndSaveImages(CreateProductOptionsCommand command, ProductOptions options) {
-        List<MainImage> mainImages = command.toMainImages(options);
-        mainImageRepository.saveAll(mainImages);
-        List<DescriptionImage> descriptionImages = command.toDescriptionImages(options);
-        descriptionImagesRepository.saveAll(descriptionImages);
+        command.toMainImages(options).forEach(options::addMainImage);
+        command.toDescriptionImages(options).forEach(options::addDescriptionImage);
+        return productOptionsRepository.save(options).getId();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/ProductQueryService.java
@@ -1,11 +1,7 @@
 package com.lovecloud.productmanagement.application;
 
-import com.lovecloud.productmanagement.domain.DescriptionImage;
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.DescriptionImageRepository;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.productmanagement.domain.repository.ProductRepository;
 import com.lovecloud.productmanagement.query.response.ProductDetailResponse;
@@ -25,41 +21,21 @@ public class ProductQueryService {
 
     private final ProductRepository productRepository;
     private final ProductOptionsRepository productOptionsRepository;
-    private final MainImageRepository mainImageRepository;
-    private final DescriptionImageRepository descriptionImageRepository;
 
     public List<ProductListResponse> findAllByCategoryId(Long categoryId) {
         List<Product> products = categoryId == null
                 ? productRepository.findAll()
                 : productRepository.findByCategoryId(categoryId);
         return products.stream()
-                .map(this::mapProductToProductListResponse)
+                .map(ProductListResponseMapper::map)
                 .collect(Collectors.toList());
     }
 
     public ProductDetailResponse findById(Long productOptionsId) {
         ProductOptions selectedOption = productOptionsRepository.findByIdAndIsDeletedOrThrow(
                 productOptionsId, false);
-        List<MainImage> mainImages = mainImageRepository.findByProductOptionsId(
-                selectedOption.getId());
-        List<DescriptionImage> descriptionImages = descriptionImageRepository.findByProductOptionsId(
-                selectedOption.getId());
         List<ProductOptions> otherOptions = productOptionsRepository.findOthersByProductId(
                 selectedOption.getProduct().getId(), selectedOption.getId());
-        return ProductDetailResponseMapper.mapProductOptionsToProductDetailResponse(selectedOption,
-                mainImages, descriptionImages, otherOptions);
-    }
-
-    private ProductListResponse mapProductToProductListResponse(Product product) {
-        List<ProductOptions> validOptions = productOptionsRepository
-                .findByProductIdAndIsDeleted(product.getId(), false);
-        if (validOptions.isEmpty()) {
-            return null;
-        }
-        return ProductListResponseMapper.mapProductToProductListResponse(
-                product,
-                validOptions,
-                mainImageRepository
-        );
+        return ProductDetailResponseMapper.map(selectedOption, otherOptions);
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
@@ -30,14 +30,19 @@ public record CreateProductOptionsCommand(
 
     public List<MainImage> toMainImages(ProductOptions productOptions) {
         return mainImageNames.stream()
-                .map(mainImageName -> MainImage.createMainImage(mainImageName, productOptions))
+                .map(mainImageName -> MainImage.builder()
+                        .mainImageName(mainImageName)
+                        .productOptions(productOptions)
+                        .build())
                 .toList();
     }
 
     public List<DescriptionImage> toDescriptionImages(ProductOptions productOptions) {
         return descriptionImageNames.stream()
-                .map(descriptionImageName -> DescriptionImage.createDescriptionImage(
-                        descriptionImageName, productOptions))
+                .map(descriptionImageName -> DescriptionImage.builder()
+                        .descriptionImageName(descriptionImageName)
+                        .productOptions(productOptions)
+                        .build())
                 .toList();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
+++ b/src/main/java/com/lovecloud/productmanagement/application/command/CreateProductOptionsCommand.java
@@ -30,19 +30,14 @@ public record CreateProductOptionsCommand(
 
     public List<MainImage> toMainImages(ProductOptions productOptions) {
         return mainImageNames.stream()
-                .map(mainImageName -> MainImage.builder()
-                        .productOptions(productOptions)
-                        .mainImageName(mainImageName)
-                        .build())
+                .map(mainImageName -> MainImage.createMainImage(mainImageName, productOptions))
                 .toList();
     }
 
     public List<DescriptionImage> toDescriptionImages(ProductOptions productOptions) {
         return descriptionImageNames.stream()
-                .map(descriptionImageName -> DescriptionImage.builder()
-                        .productOptions(productOptions)
-                        .descriptionImageName(descriptionImageName)
-                        .build())
+                .map(descriptionImageName -> DescriptionImage.createDescriptionImage(
+                        descriptionImageName, productOptions))
                 .toList();
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
@@ -38,4 +38,18 @@ public class DescriptionImage extends CommonRootEntity<Long> {
         this.descriptionImageName = descriptionImageName;
         this.productOptions = productOptions;
     }
+
+    public static DescriptionImage createDescriptionImage(String descriptionImageName, ProductOptions productOptions) {
+        return DescriptionImage.builder()
+                .descriptionImageName(descriptionImageName)
+                .productOptions(productOptions)
+                .build();
+    }
+
+    public void setProductOptions(ProductOptions productOptions) {
+        this.productOptions = productOptions;
+        if (!productOptions.getDescriptionImages().contains(this)) {
+            productOptions.getDescriptionImages().add(this);
+        }
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/DescriptionImage.java
@@ -39,13 +39,6 @@ public class DescriptionImage extends CommonRootEntity<Long> {
         this.productOptions = productOptions;
     }
 
-    public static DescriptionImage createDescriptionImage(String descriptionImageName, ProductOptions productOptions) {
-        return DescriptionImage.builder()
-                .descriptionImageName(descriptionImageName)
-                .productOptions(productOptions)
-                .build();
-    }
-
     public void setProductOptions(ProductOptions productOptions) {
         this.productOptions = productOptions;
         if (!productOptions.getDescriptionImages().contains(this)) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
@@ -38,4 +38,18 @@ public class MainImage extends CommonRootEntity<Long> {
         this.mainImageName = mainImageName;
         this.productOptions = productOptions;
     }
+
+    public static MainImage createMainImage(String mainImageName, ProductOptions productOptions) {
+        return MainImage.builder()
+                .mainImageName(mainImageName)
+                .productOptions(productOptions)
+                .build();
+    }
+
+    public void setProductOptions(ProductOptions productOptions) {
+        this.productOptions = productOptions;
+        if (!productOptions.getMainImages().contains(this)) {
+            productOptions.getMainImages().add(this);
+        }
+    }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/MainImage.java
@@ -39,13 +39,6 @@ public class MainImage extends CommonRootEntity<Long> {
         this.productOptions = productOptions;
     }
 
-    public static MainImage createMainImage(String mainImageName, ProductOptions productOptions) {
-        return MainImage.builder()
-                .mainImageName(mainImageName)
-                .productOptions(productOptions)
-                .build();
-    }
-
     public void setProductOptions(ProductOptions productOptions) {
         this.productOptions = productOptions;
         if (!productOptions.getMainImages().contains(this)) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/Product.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/Product.java
@@ -1,6 +1,7 @@
 package com.lovecloud.productmanagement.domain;
 
 import com.lovecloud.global.domain.CommonRootEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,7 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,9 +37,19 @@ public class Product extends CommonRootEntity<Long> {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ProductOptions> productOptions = new ArrayList<>();
+
     @Builder
     public Product(String productName, Category category) {
         this.productName = productName;
         this.category = category;
+    }
+
+    public void addProductOptions(ProductOptions productOption) {
+        productOptions.add(productOption);
+        if (productOption.getProduct() != this) {
+            productOption.setProduct(this);
+        }
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -56,6 +56,13 @@ public class ProductOptions extends CommonRootEntity<Long> {
         this.product = product;
     }
 
+    public void setProduct(Product product) {
+        this.product = product;
+        if (!product.getProductOptions().contains(this)) {
+            product.getProductOptions().add(this);
+        }
+    }
+
     public void addMainImage(MainImage mainImage) {
         mainImages.add(mainImage);
         if (mainImage.getProductOptions() != this) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -42,6 +42,9 @@ public class ProductOptions extends CommonRootEntity<Long> {
     @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
     private List<MainImage> mainImages;
 
+    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
+    private List<DescriptionImage> descriptionImages;
+
     @Builder
     public ProductOptions(String color, String modelName, Long price, Integer stockQuantity,
             Product product) {

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -2,6 +2,7 @@ package com.lovecloud.productmanagement.domain;
 
 import com.lovecloud.global.domain.CommonRootEntity;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,11 +40,11 @@ public class ProductOptions extends CommonRootEntity<Long> {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
-    private List<MainImage> mainImages;
+    @OneToMany(mappedBy = "productOptions", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<MainImage> mainImages = new ArrayList<>();
 
-    @OneToMany(mappedBy = "productOptions", fetch = FetchType.LAZY)
-    private List<DescriptionImage> descriptionImages;
+    @OneToMany(mappedBy = "productOptions", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<DescriptionImage> descriptionImages = new ArrayList<>();
 
     @Builder
     public ProductOptions(String color, String modelName, Long price, Integer stockQuantity,
@@ -53,5 +54,19 @@ public class ProductOptions extends CommonRootEntity<Long> {
         this.price = price;
         this.stockQuantity = stockQuantity;
         this.product = product;
+    }
+
+    public void addMainImage(MainImage mainImage) {
+        mainImages.add(mainImage);
+        if (mainImage.getProductOptions() != this) {
+            mainImage.setProductOptions(this);
+        }
+    }
+
+    public void addDescriptionImage(DescriptionImage descriptionImage) {
+        descriptionImages.add(descriptionImage);
+        if (descriptionImage.getProductOptions() != this) {
+            descriptionImage.setProductOptions(this);
+        }
     }
 }

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponse.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponse.java
@@ -5,17 +5,9 @@ import java.util.List;
 public record ProductDetailResponse(
         Long productId,
         String productName,
-        CategoryData category,
         ProductOptionDetail selectedOption,
         List<OtherOptionData> otherOptions
 ) {
-
-    public static record CategoryData(
-            Long categoryId,
-            String categoryName
-    ) {
-
-    }
 
     public static record ProductOptionDetail(
             Long productOptionsId,
@@ -26,20 +18,18 @@ public record ProductDetailResponse(
             List<ImageData> mainImages,
             List<ImageData> descriptionImages
     ) {
+        public static record ImageData(
+                Long imageId,
+                String imageName
+        ) {
 
+        }
     }
 
     public static record OtherOptionData(
             Long productOptionsId,
             String color,
             int stockQuantity
-    ) {
-
-    }
-
-    public static record ImageData(
-            Long imageId,
-            String imageName
     ) {
 
     }

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponseMapper.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductDetailResponseMapper.java
@@ -10,62 +10,48 @@ import java.util.stream.Collectors;
 
 public class ProductDetailResponseMapper {
 
-    public static ProductDetailResponse mapProductOptionsToProductDetailResponse(
-            ProductOptions selectedOption,
-            List<MainImage> mainImages,
-            List<DescriptionImage> descriptionImages,
-            List<ProductOptions> otherOptions
-    ) {
+    public static ProductDetailResponse map(ProductOptions selectedOption, List<ProductOptions> otherOptions) {
         return new ProductDetailResponse(
                 selectedOption.getProduct().getId(),
                 selectedOption.getProduct().getProductName(),
-                new ProductDetailResponse.CategoryData(
-                        selectedOption.getProduct().getCategory().getId(),
-                        selectedOption.getProduct().getCategory().getCategoryName()
-                ),
-                mapSelectedOptionDetail(selectedOption, mainImages, descriptionImages),
+                mapSelectedOptionDetail(selectedOption),
                 mapOtherOptions(otherOptions)
         );
     }
 
-    private static ProductOptionDetail mapSelectedOptionDetail(
-            ProductOptions option,
-            List<MainImage> mainImages,
-            List<DescriptionImage> descriptionImages
-    ) {
-        return new ProductDetailResponse.ProductOptionDetail(
+    private static ProductOptionDetail mapSelectedOptionDetail(ProductOptions option) {
+        return new ProductOptionDetail(
                 option.getId(),
                 option.getColor(),
                 option.getModelName(),
                 option.getPrice(),
                 option.getStockQuantity(),
-                mapMainImages(mainImages),
-                mapDescriptionImages(descriptionImages)
+                mapMainImages(option.getMainImages()),
+                mapDescriptionImages(option.getDescriptionImages())
         );
     }
 
     private static List<OtherOptionData> mapOtherOptions(List<ProductOptions> otherOptions) {
         return otherOptions.stream()
-                .map(option -> new ProductDetailResponse.OtherOptionData(
+                .map(option -> new OtherOptionData(
                         option.getId(),
                         option.getColor(),
                         option.getStockQuantity()))
                 .collect(Collectors.toList());
     }
 
-    private static List<ProductDetailResponse.ImageData> mapMainImages(List<MainImage> images) {
+    private static List<ProductOptionDetail.ImageData> mapMainImages(List<MainImage> images) {
         return images.stream()
-                .map(image -> new ProductDetailResponse.ImageData(
+                .map(image -> new ProductOptionDetail.ImageData(
                         image.getId(),
                         image.getMainImageName()
                 ))
                 .collect(Collectors.toList());
     }
 
-    private static List<ProductDetailResponse.ImageData> mapDescriptionImages(
-            List<DescriptionImage> images) {
+    private static List<ProductOptionDetail.ImageData> mapDescriptionImages(List<DescriptionImage> images) {
         return images.stream()
-                .map(image -> new ProductDetailResponse.ImageData(
+                .map(image -> new ProductOptionDetail.ImageData(
                         image.getId(),
                         image.getDescriptionImageName()
                 ))

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponse.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponse.java
@@ -8,13 +8,6 @@ public record ProductListResponse(
         List<ProductOptionSummary> options
 ) {
 
-    public static record CategoryData(
-            Long categoryId,
-            String categoryName
-    ) {
-
-    }
-
     public static record ProductOptionSummary(
             Long productOptionsId,
             String color,

--- a/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponseMapper.java
+++ b/src/main/java/com/lovecloud/productmanagement/query/response/ProductListResponseMapper.java
@@ -1,22 +1,18 @@
 package com.lovecloud.productmanagement.query.response;
 
-import com.lovecloud.productmanagement.domain.MainImage;
 import com.lovecloud.productmanagement.domain.Product;
 import com.lovecloud.productmanagement.domain.ProductOptions;
-import com.lovecloud.productmanagement.domain.repository.MainImageRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
 
 public class ProductListResponseMapper {
 
-    public static ProductListResponse mapProductToProductListResponse(
-            Product product,
-            List<ProductOptions> options,
-            MainImageRepository mainImageRepository
-    ) {
-        List<ProductListResponse.ProductOptionSummary> optionSummaries = options.stream()
-                .map(option -> mapProductOptionToProductOptionSummary(option, mainImageRepository))
+    public static ProductListResponse map(Product product) {
+        List<ProductListResponse.ProductOptionSummary> optionSummaries = product.getProductOptions()
+                .stream()
+                .filter(option -> !option.getIsDeleted())
+                .map(ProductListResponseMapper::mapProductOptionToProductOptionSummary)
                 .collect(Collectors.toList());
 
         return new ProductListResponse(
@@ -27,11 +23,9 @@ public class ProductListResponseMapper {
     }
 
     private static ProductListResponse.ProductOptionSummary mapProductOptionToProductOptionSummary(
-            ProductOptions option,
-            MainImageRepository mainImageRepository
-    ) {
-        List<MainImage> mainImages = mainImageRepository.findByProductOptionsId(option.getId());
-        List<ProductListResponse.ProductOptionSummary.ImageData> imageDatas = mainImages.stream()
+            ProductOptions option) {
+        List<ProductListResponse.ProductOptionSummary.ImageData> imageDatas = option.getMainImages()
+                .stream()
                 .map(image -> new ProductListResponse.ProductOptionSummary.ImageData(
                         image.getId(),
                         image.getMainImageName()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #110 

## 💗 작업 동기
신혼부부가 주문을 하기 위해, 주문 가능한 펀딩 목록을 제공하는 기능이 필요합니다.

주문 가능한 펀딩 목록을 조회하는 방법에 대해 두 가지 접근 방법을 고민했습니다. 

#### 방법 1. SQL로 직접 조회
첫 번째 방법은 SQL로 데이터를 필터링하고 조회할 수 있어, 최적화가 가능합니다. 또한 상태 관리의 복잡성이 줄일 수 있습니다. 그러나 가독성 문제, DB 구조나 인덱스에 따라 성능이 달라질 수 있습니다.

#### 방법 2. FundingStatus에 주문한 상태를 추가하여 조회
두 번째 방법은 객체 상태를 통해 데이터를 조회할 수 있어, 가독성이 좋고, 객체지향적인 접근 방식을 유지할 수 있습니다. 그러나 상태 관리가 복잡해질 수 있습니다.

세밀하고 최적화된 조회를 위해 SQL로 직접 조회하는 방식을 선택했습니다. 불필요한 상태 관리를 줄이고, SQL 최적화를 통해 성능을 향상시킬 수 있습니다.

이후 주문 가능한 펀딩 목록 조회 기능을 구현하였습니다. 주문 가능한 펀딩은 `특정 부부의 FundingStatus가 COMPLETED이며, 관련된 OrderDetail이 없거나 OrderStatus가 CANCEL_COMPLETED인 펀딩을 의미합니다.

기능 구현 후, SQL 최적화 작업을 하였습니다. 

#### 1번 방법: LEFT JOIN을 사용한 조회
```java
@Query("SELECT f FROM Funding f " +
            "LEFT JOIN OrderDetails od ON f.id = od.funding.id " +
            "LEFT JOIN Order o ON od.order.id = o.id " +
            "WHERE f.couple.id = :coupleId AND f.status = 'COMPLETED' AND " +
            "(o IS NULL OR o.orderStatus = 'CANCEL_COMPLETED')")
    List<Funding> findOrderableFundingsByCoupleId(@Param("coupleId") Long coupleId);
```

#### 1번 방법 SQL 로그
```
select
    f1_0.funding_id,
    f1_0.couple_id,
    f1_0.created_date,
    f1_0.current_amount,
    f1_0.end_date,
    f1_0.message,
    f1_0.product_options_id,
    f1_0.funding_status,
    f1_0.target_amount,
    f1_0.title,
    f1_0.updated_date 
from
    funding f1_0 
left join
    order_details od1_0 
        on f1_0.funding_id=od1_0.funding_id 
left join
    orders o1_0 
        on od1_0.order_id=o1_0.order_id 
where
    f1_0.couple_id=? 
    and f1_0.funding_status='COMPLETED' 
    and (
        o1_0.order_id is null 
        or o1_0.order_status='CANCEL_COMPLETED'
    )
```

쿼리가 직관적이나, 여러 테이블을 걸쳐 조인을 수행하여 성능 저하 가능성이 있습니다. 또한 OrderDetail 및 Order 테이블이 클 경우 불필요한 데이터 로드가 발생합니다.

#### 2번 방법: NOT EXISTS를 사용한 조회
```java
@Query("SELECT f FROM Funding f " +
            "WHERE f.couple.id = :coupleId AND f.status = 'COMPLETED' AND " +
            "NOT EXISTS (SELECT od FROM OrderDetails od WHERE od.funding.id = f.id AND od.order.orderStatus != 'CANCEL_COMPLETED')")
    List<Funding> findOrderableFundingsByCoupleId(@Param("coupleId") Long coupleId);
```

#### 2번 방법 SQL 로그
```
select
    f1_0.funding_id,
    f1_0.couple_id,
    f1_0.created_date,
    f1_0.current_amount,
    f1_0.end_date,
    f1_0.message,
    f1_0.product_options_id,
    f1_0.funding_status,
    f1_0.target_amount,
    f1_0.title,
    f1_0.updated_date 
from
    funding f1_0 
where
    f1_0.couple_id=? 
    and f1_0.funding_status='COMPLETED' 
    and not exists(
        select
            od1_0.order_details_id 
        from
            order_details od1_0 
        join
            orders o1_0 on od1_0.order_id=o1_0.order_id 
        where
            od1_0.funding_id=f1_0.funding_id 
            and o1_0.order_status<>'CANCEL_COMPLETED')
```

서브쿼리를 사용하여 주문 상태가 CANCEL_COMPLETED가 아닌 주문을 가진 펀딩만 제외하므로 필요한 데이터만 가져와 DB에 부담이 줄일 수 있습니다. 그러나 서브쿼리는 경우에 따라 비효율적으로 동작한다는 단점이 있습니다.

#### 3번 방법: 조인과 NOT EXISTS 결합 사용
```java
@Query("SELECT f FROM Funding f " +
        "WHERE f.couple.id = :coupleId AND f.status = 'COMPLETED' AND " +
        "NOT EXISTS (SELECT od FROM OrderDetails od JOIN Order o ON od.order.id = o.id " +
        "WHERE od.funding.id = f.id AND o.orderStatus <> 'CANCEL_COMPLETED')")
List<Funding> findOrderableFundingsByCoupleId(@Param("coupleId") Long coupleId);
```

#### 3번 방법 SQL 로그
```
select
    f1_0.funding_id,
    f1_0.couple_id,
    f1_0.created_date,
    f1_0.current_amount,
    f1_0.end_date,
    f1_0.message,
    f1_0.product_options_id,
    f1_0.funding_status,
    f1_0.target_amount,
    f1_0.title,
    f1_0.updated_date 
from
    funding f1_0 
where
    f1_0.couple_id=? 
    and f1_0.funding_status='COMPLETED' 
    and not exists(select
        od1_0.order_details_id 
    from
        order_details od1_0 
    join
        orders o1_0 
            on od1_0.order_id=o1_0.order_id 
    where
        od1_0.funding_id=f1_0.funding_id 
        and o1_0.order_status<>'CANCEL_COMPLETED')
```

NOT EXISTS를 사용하여 불필요한 데이터 로드를 방지하며, 조인을 사용하여 CANCEL_COMPLETED가 아닌 경우만 포함시킵니다. 그러나 쿼리가 복잡해진다는 단점이 있습니다.

## 🛠️ 작업 내용
- [x] 주문 가능한 펀딩 목록 조회 방법 구현 방법 결정
- [x] 주문 가능한 펀딩 목록 조회 기능 구현 
- [x] SQL 최적화 작업

## 🎯 리뷰 포인트
최종 선택한 방법이 최적의 선택인지 검토 부탁드립니다.

#### 기타 정보
- 연관 관계
    - Product —1—————N— `ProductOption` (양방향)
    - ProductOption —1—————N— `Funding`
    - Order —1—————N— `OrderDetail` (양방향)
    - Funding —1—————1— `OrderDetail`
- 주문 가능한 펀딩
    - Funding A 객체의 FundingStatus가 COMPLETED이고, fundingId가 A.fundingId인 OrderDetail가 없거나 OrderDetail의 Order의 OrderStatus가 CANCEL_COMPLETED인 경우를 필터링합니다.

## ✅ 테스트 결과
![image](https://github.com/yu-LoveCloud/love-cloud-was/assets/96174711/1fe270a5-6b77-4d25-b154-f8afe3cae99e)