### PR TITLE
refactor: 청첩장관리, 주문관리에 현재 로그인한 사용자 정보 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.17.53')
     implementation 'software.amazon.awssdk:s3'
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/lovecloud/invitationmanagement/presentation/InvitationController.java
+++ b/src/main/java/com/lovecloud/invitationmanagement/presentation/InvitationController.java
@@ -1,5 +1,6 @@
 package com.lovecloud.invitationmanagement.presentation;
 
+import com.lovecloud.global.usermanager.SecurityUser;
 import com.lovecloud.invitationmanagement.application.InvitationCreateService;
 import com.lovecloud.invitationmanagement.presentation.request.CreateInvitationRequest;
 import com.lovecloud.usermanagement.application.CoupleService;
@@ -7,6 +8,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -19,16 +22,15 @@ public class InvitationController {
     private final InvitationCreateService invitationCreateService;
     private final CoupleService coupleService;
 
-    //TODO: 인증 및 유저 정보 가져오기 구현
-    //@Auth(role = Role.USER)
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     public ResponseEntity<Long> invitationAdd(@Valid @RequestBody CreateInvitationRequest request,
-                                              Long userId )
+                                              @AuthenticationPrincipal SecurityUser securityUser)
     {
 
         final Long invitationId = invitationCreateService.addInvitation(request.toCommand());
-        coupleService.updateCoupleInvitation(userId,invitationId);
+        coupleService.updateCoupleInvitation(securityUser.user().getId(), invitationId);
 
         return ResponseEntity.created(URI.create("/invitations/" + invitationId)).build();
     }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/Delivery.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/Delivery.java
@@ -43,7 +43,7 @@ public class Delivery extends CommonRootEntity<Long> {
     @Column(name = "detail_address", nullable = false, length = 100)
     private String detailAddress;
 
-    @Column(name = "delivery_memo", nullable = false, length = 100)
+    @Column(name = "delivery_memo", length = 100)
     private String deliveryMemo;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lovecloud/ordermanagement/domain/Order.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/Order.java
@@ -29,7 +29,7 @@ public class Order extends CommonRootEntity<Long> {
     @Column(name = "orderer_phone_number", nullable = false, length = 100)
     private String ordererPhoneNumber;
 
-    @Column(name = "orderer_memo", nullable = false, length = 100)
+    @Column(name = "orderer_memo", length = 100)
     private String ordererMemo;
 
     @Column(name = "order_number", nullable = false, length = 100)

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
@@ -1,14 +1,15 @@
 package com.lovecloud.ordermanagement.presentation;
 
+import com.lovecloud.global.usermanager.SecurityUser;
 import com.lovecloud.ordermanagement.application.OrderCreateService;
 import com.lovecloud.ordermanagement.presentation.request.CreateOrderRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -19,9 +20,11 @@ public class OrderController {
     private final OrderCreateService orderCreateService;
 
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     public ResponseEntity<Long> createOrder(@Valid @RequestBody CreateOrderRequest request,
-                                            Long userId) {
-        final Long orderId = orderCreateService.createOrder(request.toCommand(userId));
+                                            @AuthenticationPrincipal SecurityUser securityUser) {
+        final Long orderId = orderCreateService.createOrder(request.toCommand(securityUser.user().getId()));
         return ResponseEntity.created(URI.create("/orders/" + orderId)).build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/OrderQueryController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/OrderQueryController.java
@@ -1,10 +1,13 @@
 package com.lovecloud.ordermanagement.presentation;
 
+import com.lovecloud.global.usermanager.SecurityUser;
 import com.lovecloud.ordermanagement.application.OrderQueryService;
 import com.lovecloud.ordermanagement.query.response.OrderDetailResponse;
 import com.lovecloud.ordermanagement.query.response.OrderListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,15 +21,19 @@ import java.util.List;
 public class OrderQueryController {
     private final OrderQueryService orderQueryService;
 
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderDetailResponse> detailOrder(@PathVariable Long orderId, Long userId) {
-        final OrderDetailResponse order = orderQueryService.findById(orderId, userId);
+    public ResponseEntity<OrderDetailResponse> detailOrder(@PathVariable Long orderId,
+                                                           @AuthenticationPrincipal SecurityUser securityUser) {
+        final OrderDetailResponse order = orderQueryService.findById(orderId, securityUser.user().getId());
         return ResponseEntity.ok(order);
     }
 
     @GetMapping
-    public ResponseEntity<List<OrderListResponse>> listOrders(Long userId) {
-        final List<OrderListResponse> orders = orderQueryService.findAllByUserId(userId);
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<List<OrderListResponse>> listOrders(
+            @AuthenticationPrincipal SecurityUser securityUser) {
+        final List<OrderListResponse> orders = orderQueryService.findAllByUserId(securityUser.user().getId());
         return ResponseEntity.ok(orders);
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateOrderRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateOrderRequest.java
@@ -27,6 +27,8 @@ public record CreateOrderRequest(
         String zipcode,
         @NotBlank
         String address,
+
+        @NotBlank
         String detailAddress,
         String deliveryMemo
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #116

## 💗 작업 동기
청첩장 관리, 주문관리 api에 현재 로그인한 사용자 정보를 적용시킴

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] @PreAuthorize 어노테이션으로 권한 검증 추가
- [x] @AuthenticationPrincipal 어노테이션으로 로그인한 사용자 정보를 가져옴
- [x] (주문시 ordererMemo, deliveryMemo가 null일 수 있도록 변경)
- [x] (swaggerUI 의존성추가)

## 🎯 리뷰 포인트
청첩장 조회는 모든 사람이 할 수 있도록 권한검증로직을 추가하지 않았습니다.

## ✅ 테스트 결과
<img width="535" alt="image" src="https://github.com/yu-LoveCloud/love-cloud-was/assets/101257697/a9b59d18-7e58-4977-98b2-6c13d87000f0">

<img width="505" alt="image" src="https://github.com/yu-LoveCloud/love-cloud-was/assets/101257697/f1a54119-0001-4d52-85e6-233786371b03">

