### PR TITLE
Feat/#68

### DIFF
--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -44,6 +44,10 @@ public class SecurityConfig {
             "/items/**",
             "/invitations/**",
             "/fundings/**",
+
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui.html"
     };
 
 

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressQueryService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressQueryService.java
@@ -1,0 +1,31 @@
+package com.lovecloud.ordermanagement.application;
+
+import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+import com.lovecloud.ordermanagement.domain.repository.DeliveryAddressRepository;
+import com.lovecloud.ordermanagement.query.response.DeliveryAddressResponse;
+import com.lovecloud.usermanagement.domain.Couple;
+import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeliveryAddressQueryService {
+    private final DeliveryAddressRepository deliveryAddressRepository;
+    private final CoupleRepository coupleRepository;
+    public List<DeliveryAddressResponse> findAllDeliveryAddressesByUserId(Long userId) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
+        List<DeliveryAddress> deliveryAddresses = deliveryAddressRepository.findAllByCoupleId(couple.getId());
+        return deliveryAddresses.stream()
+                .map(DeliveryAddressResponse::from)
+                .sorted(Comparator.comparing(DeliveryAddressResponse::isDefault).reversed())
+                .toList();
+    }
+
+
+}

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressQueryService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressQueryService.java
@@ -28,4 +28,15 @@ public class DeliveryAddressQueryService {
     }
 
 
+    public DeliveryAddressResponse findDeliveryAddressByDeliveryAddressIdAndUserId(Long userId, Long deliveryAddressId) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
+        DeliveryAddress deliveryAddress = deliveryAddressRepository.findByIdAndCoupleIdOrThrow(deliveryAddressId,couple.getId());
+        return DeliveryAddressResponse.from(deliveryAddress);
+    }
+
+    public DeliveryAddressResponse findDefaultDeliveryAddressByUserId(Long id) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(id);
+        DeliveryAddress deliveryAddress = deliveryAddressRepository.findDefaultAddressByCoupleIdOrThrow(couple.getId());
+        return DeliveryAddressResponse.from(deliveryAddress);
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
@@ -1,0 +1,22 @@
+package com.lovecloud.ordermanagement.application;
+
+import com.lovecloud.ordermanagement.application.command.CreateDeliveryAddressCommand;
+import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+import com.lovecloud.ordermanagement.domain.repository.DeliveryAddressRepository;
+import com.lovecloud.usermanagement.domain.Couple;
+import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryAddressService {
+    private final DeliveryAddressRepository deliveryAddressRepository;
+    private final CoupleRepository coupleRepository;
+
+    public Long createDeliveryAddress(CreateDeliveryAddressCommand command) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
+        DeliveryAddress deliveryAddress = command.toDeliveryAddress(couple);
+        return deliveryAddressRepository.save(deliveryAddress).getId();
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
@@ -1,8 +1,10 @@
 package com.lovecloud.ordermanagement.application;
 
 import com.lovecloud.ordermanagement.application.command.CreateDeliveryAddressCommand;
+import com.lovecloud.ordermanagement.application.command.UpdateDeliveryAddressCommand;
 import com.lovecloud.ordermanagement.domain.DeliveryAddress;
 import com.lovecloud.ordermanagement.domain.repository.DeliveryAddressRepository;
+import com.lovecloud.ordermanagement.exception.UnauthorizedDeliveryAddressException;
 import com.lovecloud.usermanagement.domain.Couple;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,22 @@ public class DeliveryAddressService {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
         DeliveryAddress deliveryAddress = command.toDeliveryAddress(couple);
         return deliveryAddressRepository.save(deliveryAddress).getId();
+    }
+
+    public Long updateDeliveryAddress(UpdateDeliveryAddressCommand command) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
+        DeliveryAddress deliveryAddress = deliveryAddressRepository.findByIdOrThrow(command.deliveryAddressId());
+
+        //본인의 배송지인지 검증
+        validateOwner(deliveryAddress, couple);
+
+        deliveryAddress.update(command);
+        return deliveryAddress.getId();
+    }
+
+    private static void validateOwner(DeliveryAddress deliveryAddress, Couple couple) {
+        if (!deliveryAddress.getCouple().getId().equals(couple.getId())) {
+            throw new UnauthorizedDeliveryAddressException();
+        }
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
@@ -33,9 +33,20 @@ public class DeliveryAddressService {
         return deliveryAddress.getId();
     }
 
+    public void deleteDeliveryAddress(Long userId, Long deliveryAddressId) {
+        Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
+        DeliveryAddress deliveryAddress = deliveryAddressRepository.findByIdOrThrow(deliveryAddressId);
+
+        //본인의 배송지인지 검증
+        validateOwner(deliveryAddress, couple);
+
+        deliveryAddressRepository.delete(deliveryAddress);
+    }
+
     private static void validateOwner(DeliveryAddress deliveryAddress, Couple couple) {
         if (!deliveryAddress.getCouple().getId().equals(couple.getId())) {
             throw new UnauthorizedDeliveryAddressException();
         }
     }
+
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
@@ -24,7 +24,7 @@ public class DeliveryAddressService {
         Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
         DeliveryAddress deliveryAddress = deliveryAddressRepository.findByIdOrThrow(deliveryAddressId);
         validateOwner(deliveryAddress, couple);
-        updateDefaultDeliveryAddress(userId, deliveryAddressId);
+        updateDefaultDeliveryAddress(couple.getId(), deliveryAddressId);
     }
 
     public Long createDeliveryAddress(CreateDeliveryAddressCommand command) {
@@ -33,7 +33,7 @@ public class DeliveryAddressService {
 
         DeliveryAddress savedDeliveryAddress = deliveryAddressRepository.save(deliveryAddress);
         if (command.isDefault()) {
-            updateDefaultDeliveryAddress(command.userId(), savedDeliveryAddress.getId());
+            updateDefaultDeliveryAddress(couple.getId(), savedDeliveryAddress.getId());
         }
         return savedDeliveryAddress.getId();
     }
@@ -48,7 +48,7 @@ public class DeliveryAddressService {
 
         deliveryAddress.update(command);
         if(command.isDefault()){
-            updateDefaultDeliveryAddress(command.userId(), command.deliveryAddressId());
+            updateDefaultDeliveryAddress(couple.getId(), command.deliveryAddressId());
         }
 
         return deliveryAddress.getId();
@@ -64,10 +64,10 @@ public class DeliveryAddressService {
         deliveryAddressRepository.delete(deliveryAddress);
     }
 
-    private void updateDefaultDeliveryAddress(Long userId, Long deliveryAddressId) {
+    private void updateDefaultDeliveryAddress(Long coupleId, Long deliveryAddressId) {
 
         // 1. 해당 사용자의 모든 배송지를 가져옴
-        List<DeliveryAddress> userAddresses = deliveryAddressRepository.findAllByUserId(userId);
+        List<DeliveryAddress> userAddresses = deliveryAddressRepository.findAllByCoupleId(coupleId);
 
         // 2. 새로운 기본 배송지를 찾아 기본으로 설정하고, 나머지는 일반 배송지로 설정
         for (DeliveryAddress address : userAddresses) {

--- a/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/DeliveryAddressService.java
@@ -10,6 +10,8 @@ import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class DeliveryAddressService {
@@ -19,8 +21,14 @@ public class DeliveryAddressService {
     public Long createDeliveryAddress(CreateDeliveryAddressCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
         DeliveryAddress deliveryAddress = command.toDeliveryAddress(couple);
-        return deliveryAddressRepository.save(deliveryAddress).getId();
+
+        DeliveryAddress savedDeliveryAddress = deliveryAddressRepository.save(deliveryAddress);
+        if (command.isDefault()) {
+            setDefaultDeliveryAddress(command.userId(), savedDeliveryAddress.getId());
+        }
+        return savedDeliveryAddress.getId();
     }
+
 
     public Long updateDeliveryAddress(UpdateDeliveryAddressCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
@@ -30,6 +38,10 @@ public class DeliveryAddressService {
         validateOwner(deliveryAddress, couple);
 
         deliveryAddress.update(command);
+        if(command.isDefault()){
+            setDefaultDeliveryAddress(command.userId(), command.deliveryAddressId());
+        }
+
         return deliveryAddress.getId();
     }
 
@@ -43,10 +55,28 @@ public class DeliveryAddressService {
         deliveryAddressRepository.delete(deliveryAddress);
     }
 
+    private void setDefaultDeliveryAddress(Long userId, Long deliveryAddressId) {
+
+        // 1. 해당 사용자의 모든 배송지를 가져옴
+        List<DeliveryAddress> userAddresses = deliveryAddressRepository.findAllByUserId(userId);
+
+        // 2. 새로운 기본 배송지를 찾아 기본으로 설정하고, 나머지는 일반 배송지로 설정
+        for (DeliveryAddress address : userAddresses) {
+            if (address.getId().equals(deliveryAddressId)) {
+                address.setDefault(true);  // 새로운 기본 배송지로 설정
+            } else {
+                address.setDefault(false);  // 나머지는 일반 배송지로 설정
+            }
+        }
+
+        // 3. 변경된 배송지들을 저장
+        deliveryAddressRepository.saveAll(userAddresses);
+
+    }
+
     private static void validateOwner(DeliveryAddress deliveryAddress, Couple couple) {
         if (!deliveryAddress.getCouple().getId().equals(couple.getId())) {
             throw new UnauthorizedDeliveryAddressException();
         }
     }
-
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/command/CreateDeliveryAddressCommand.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/command/CreateDeliveryAddressCommand.java
@@ -11,7 +11,10 @@ public record CreateDeliveryAddressCommand(
         String zipCode,
         String address,
         String detailAddress,
-        String deliveryMemo
+        String deliveryMemo,
+        String receiverName,
+        String receiverPhoneNumber,
+        boolean isDefault
 ) {
     public DeliveryAddress toDeliveryAddress(Couple couple) {
         return DeliveryAddress.builder()
@@ -21,6 +24,8 @@ public record CreateDeliveryAddressCommand(
                 .detailAddress(detailAddress())
                 .deliveryMemo(deliveryMemo())
                 .couple(couple)
+                .receiverName(receiverName())
+                .receiverPhoneNumber(receiverPhoneNumber())
                 .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/command/CreateDeliveryAddressCommand.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/command/CreateDeliveryAddressCommand.java
@@ -1,0 +1,26 @@
+package com.lovecloud.ordermanagement.application.command;
+
+import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+import com.lovecloud.usermanagement.domain.Couple;
+import lombok.Builder;
+
+@Builder
+public record CreateDeliveryAddressCommand(
+        Long userId,
+        String deliveryName,
+        String zipCode,
+        String address,
+        String detailAddress,
+        String deliveryMemo
+) {
+    public DeliveryAddress toDeliveryAddress(Couple couple) {
+        return DeliveryAddress.builder()
+                .deliveryName(deliveryName())
+                .zipCode(zipCode())
+                .address(address())
+                .detailAddress(detailAddress())
+                .deliveryMemo(deliveryMemo())
+                .couple(couple)
+                .build();
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/application/command/UpdateDeliveryAddressCommand.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/command/UpdateDeliveryAddressCommand.java
@@ -10,6 +10,9 @@ public record UpdateDeliveryAddressCommand(
         String zipCode,
         String address,
         String detailAddress,
-        String deliveryMemo
+        String deliveryMemo,
+        String receiverName,
+        String receiverPhoneNumber,
+        boolean isDefault
 ) {
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/command/UpdateDeliveryAddressCommand.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/command/UpdateDeliveryAddressCommand.java
@@ -1,0 +1,15 @@
+package com.lovecloud.ordermanagement.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateDeliveryAddressCommand(
+        Long userId,
+        Long deliveryAddressId,
+        String deliveryName,
+        String zipCode,
+        String address,
+        String detailAddress,
+        String deliveryMemo
+) {
+}

--- a/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
@@ -76,6 +76,8 @@ public class DeliveryAddress extends CommonRootEntity<Long> {
         this.address = command.address();
         this.detailAddress = command.detailAddress();
         this.deliveryMemo = command.deliveryMemo();
+        this.receiverName = command.receiverName();
+        this.receiverPhoneNumber = command.receiverPhoneNumber();
     }
 
     public void setDefault(boolean isDefault) {

--- a/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
@@ -49,6 +49,9 @@ public class DeliveryAddress extends CommonRootEntity<Long> {
     @Column(name = "delivery_memo", nullable = false, length = 100)
     private String deliveryMemo;
 
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "couple_id", nullable = false)
     private Couple couple;
@@ -74,4 +77,9 @@ public class DeliveryAddress extends CommonRootEntity<Long> {
         this.detailAddress = command.detailAddress();
         this.deliveryMemo = command.deliveryMemo();
     }
+
+    public void setDefault(boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/DeliveryAddress.java
@@ -1,6 +1,7 @@
 package com.lovecloud.ordermanagement.domain;
 
 import com.lovecloud.global.domain.CommonRootEntity;
+import com.lovecloud.ordermanagement.application.command.UpdateDeliveryAddressCommand;
 import com.lovecloud.usermanagement.domain.Couple;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -64,5 +65,13 @@ public class DeliveryAddress extends CommonRootEntity<Long> {
         this.detailAddress = detailAddress;
         this.deliveryMemo = deliveryMemo;
         this.couple = couple;
+    }
+
+    public void update(UpdateDeliveryAddressCommand command) {
+        this.deliveryName = command.deliveryName();
+        this.zipCode = command.zipCode();
+        this.address = command.address();
+        this.detailAddress = command.detailAddress();
+        this.deliveryMemo = command.deliveryMemo();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
@@ -1,7 +1,12 @@
 package com.lovecloud.ordermanagement.domain.repository;
 
 import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+import com.lovecloud.ordermanagement.exception.DeliveryAddressNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
+
+    default DeliveryAddress findByIdOrThrow(Long id){
+        return findById(id).orElseThrow(DeliveryAddressNotFoundException::new);
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
@@ -3,8 +3,10 @@ package com.lovecloud.ordermanagement.domain.repository;
 import com.lovecloud.ordermanagement.domain.DeliveryAddress;
 import com.lovecloud.ordermanagement.exception.DeliveryAddressNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
 
@@ -13,4 +15,17 @@ public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress
     }
 
     List<DeliveryAddress> findAllByCoupleId(Long coupleId);
+
+    Optional<DeliveryAddress> findByIdAndCoupleId(Long deliveryAddressId, Long coupleId);
+
+    default DeliveryAddress findByIdAndCoupleIdOrThrow(Long deliveryAddressId, Long coupleId){
+        return findByIdAndCoupleId(deliveryAddressId, coupleId).orElseThrow(DeliveryAddressNotFoundException::new);
+    }
+
+    @Query("select da from DeliveryAddress da where da.couple.id = :coupleId and da.isDefault = true")
+    Optional<DeliveryAddress> findDefaultAddressByCoupleId(Long coupleId);
+
+    default DeliveryAddress findDefaultAddressByCoupleIdOrThrow(Long id) {
+        return findDefaultAddressByCoupleId(id).orElseThrow(DeliveryAddressNotFoundException::new);
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
@@ -12,5 +12,5 @@ public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress
         return findById(id).orElseThrow(DeliveryAddressNotFoundException::new);
     }
 
-    List<DeliveryAddress> findAllByUserId(Long userId);
+    List<DeliveryAddress> findAllByCoupleId(Long coupleId);
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
@@ -4,9 +4,13 @@ import com.lovecloud.ordermanagement.domain.DeliveryAddress;
 import com.lovecloud.ordermanagement.exception.DeliveryAddressNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
 
     default DeliveryAddress findByIdOrThrow(Long id){
         return findById(id).orElseThrow(DeliveryAddressNotFoundException::new);
     }
+
+    List<DeliveryAddress> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/DeliveryAddressRepository.java
@@ -1,0 +1,7 @@
+package com.lovecloud.ordermanagement.domain.repository;
+
+import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
+}

--- a/src/main/java/com/lovecloud/ordermanagement/exception/DeliveryAddressNotFoundException.java
+++ b/src/main/java/com/lovecloud/ordermanagement/exception/DeliveryAddressNotFoundException.java
@@ -1,0 +1,13 @@
+package com.lovecloud.ordermanagement.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public class DeliveryAddressNotFoundException extends LoveCloudException {
+    public DeliveryAddressNotFoundException() {
+        super(new ErrorCode(NOT_FOUND, "존재하지 않는 배송지입니다."));
+    }
+
+}

--- a/src/main/java/com/lovecloud/ordermanagement/exception/UnauthorizedDeliveryAddressException.java
+++ b/src/main/java/com/lovecloud/ordermanagement/exception/UnauthorizedDeliveryAddressException.java
@@ -1,0 +1,12 @@
+package com.lovecloud.ordermanagement.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+public class UnauthorizedDeliveryAddressException extends LoveCloudException {
+    public UnauthorizedDeliveryAddressException() {
+        super(new ErrorCode(FORBIDDEN,"배송지 접근 권한이 없습니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
@@ -1,0 +1,36 @@
+package com.lovecloud.ordermanagement.presentation;
+
+import com.lovecloud.global.usermanager.SecurityUser;
+import com.lovecloud.ordermanagement.application.DeliveryAddressService;
+import com.lovecloud.ordermanagement.presentation.request.CreateDeliveryAddressRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/delivery-addresses")
+public class DeliveryAddressController {
+
+    private final DeliveryAddressService deliveryAddressService;
+
+    //내 배송지 저장
+    @PostMapping
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<Long> createDeliveryAddress(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @Valid @RequestBody CreateDeliveryAddressRequest request
+    ) {
+        final Long userId = securityUser.user().getId();
+        Long deliveryAddressId = deliveryAddressService.createDeliveryAddress(request.toCommand(userId));
+        return ResponseEntity.created(URI.create("/delivery-addresses/" + deliveryAddressId)).build();
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
@@ -56,4 +56,16 @@ public class DeliveryAddressController {
         deliveryAddressService.deleteDeliveryAddress(userId, deliveryAddressId);
         return ResponseEntity.noContent().build();
     }
+
+    //기본 배송지 설정
+    @PutMapping("/{deliveryAddressId}/default")
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<Void> setDefaultDeliveryAddress(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable Long deliveryAddressId
+    ) {
+        final Long userId = securityUser.user().getId();
+        deliveryAddressService.setDefaultDeliveryAddress(userId, deliveryAddressId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
@@ -44,4 +44,16 @@ public class DeliveryAddressController {
         Long id = deliveryAddressService.updateDeliveryAddress(request.toCommand(userId, deliveryAddressId));
         return ResponseEntity.ok().build();
     }
+
+    //내 배송지 삭제
+    @DeleteMapping("/{deliveryAddressId}")
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<Void> deleteDeliveryAddress(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable Long deliveryAddressId
+    ) {
+        final Long userId = securityUser.user().getId();
+        deliveryAddressService.deleteDeliveryAddress(userId, deliveryAddressId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressController.java
@@ -3,15 +3,13 @@ package com.lovecloud.ordermanagement.presentation;
 import com.lovecloud.global.usermanager.SecurityUser;
 import com.lovecloud.ordermanagement.application.DeliveryAddressService;
 import com.lovecloud.ordermanagement.presentation.request.CreateDeliveryAddressRequest;
+import com.lovecloud.ordermanagement.presentation.request.UpdateDeliveryAddressRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -32,5 +30,18 @@ public class DeliveryAddressController {
         final Long userId = securityUser.user().getId();
         Long deliveryAddressId = deliveryAddressService.createDeliveryAddress(request.toCommand(userId));
         return ResponseEntity.created(URI.create("/delivery-addresses/" + deliveryAddressId)).build();
+    }
+
+    //내 배송지 수정
+    @PutMapping("/{deliveryAddressId}")
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<Long> updateDeliveryAddress(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable Long deliveryAddressId,
+            @Valid @RequestBody UpdateDeliveryAddressRequest request
+    ) {
+        final Long userId = securityUser.user().getId();
+        Long id = deliveryAddressService.updateDeliveryAddress(request.toCommand(userId, deliveryAddressId));
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -31,7 +28,7 @@ public class DeliveryAddressQueryController {
     // 배송지 상세 조회
     @GetMapping("/{deliveryAddressId}")
     @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
-    public ResponseEntity<DeliveryAddressResponse> detailDeliveryAddress(@AuthenticationPrincipal SecurityUser securityUser, @RequestParam Long deliveryAddressId) {
+    public ResponseEntity<DeliveryAddressResponse> detailDeliveryAddress(@AuthenticationPrincipal SecurityUser securityUser, @PathVariable Long deliveryAddressId) {
         DeliveryAddressResponse deliveryAddress = deliveryAddressQueryService.findDeliveryAddressByDeliveryAddressIdAndUserId(securityUser.user().getId(), deliveryAddressId);
         return ResponseEntity.ok(deliveryAddress);
     }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
@@ -4,10 +4,12 @@ import com.lovecloud.global.usermanager.SecurityUser;
 import com.lovecloud.ordermanagement.application.DeliveryAddressQueryService;
 import com.lovecloud.ordermanagement.query.response.DeliveryAddressResponse;
 import lombok.RequiredArgsConstructor;
-import okhttp3.Response;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -19,12 +21,25 @@ public class DeliveryAddressQueryController {
     private final DeliveryAddressQueryService deliveryAddressQueryService;
 
     // 내 배송지 목록 조회
+    @GetMapping
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     public ResponseEntity<List<DeliveryAddressResponse>> listDeliveryAddresses(@AuthenticationPrincipal SecurityUser securityUser) {
         List<DeliveryAddressResponse> deliveryAddresses = deliveryAddressQueryService.findAllDeliveryAddressesByUserId(securityUser.user().getId());
         return ResponseEntity.ok(deliveryAddresses);
     }
 
     // 배송지 상세 조회
-
+    @GetMapping("/{deliveryAddressId}")
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<DeliveryAddressResponse> detailDeliveryAddress(@AuthenticationPrincipal SecurityUser securityUser, @RequestParam Long deliveryAddressId) {
+        DeliveryAddressResponse deliveryAddress = deliveryAddressQueryService.findDeliveryAddressByDeliveryAddressIdAndUserId(securityUser.user().getId(), deliveryAddressId);
+        return ResponseEntity.ok(deliveryAddress);
+    }
     // 기본 배송지 조회
+    @GetMapping("/default")
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public ResponseEntity<DeliveryAddressResponse> defaultDeliveryAddress(@AuthenticationPrincipal SecurityUser securityUser) {
+        DeliveryAddressResponse deliveryAddress = deliveryAddressQueryService.findDefaultDeliveryAddressByUserId(securityUser.user().getId());
+        return ResponseEntity.ok(deliveryAddress);
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/DeliveryAddressQueryController.java
@@ -1,0 +1,30 @@
+package com.lovecloud.ordermanagement.presentation;
+
+import com.lovecloud.global.usermanager.SecurityUser;
+import com.lovecloud.ordermanagement.application.DeliveryAddressQueryService;
+import com.lovecloud.ordermanagement.query.response.DeliveryAddressResponse;
+import lombok.RequiredArgsConstructor;
+import okhttp3.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/delivery-addresses")
+@RequiredArgsConstructor
+public class DeliveryAddressQueryController {
+    private final DeliveryAddressQueryService deliveryAddressQueryService;
+
+    // 내 배송지 목록 조회
+    public ResponseEntity<List<DeliveryAddressResponse>> listDeliveryAddresses(@AuthenticationPrincipal SecurityUser securityUser) {
+        List<DeliveryAddressResponse> deliveryAddresses = deliveryAddressQueryService.findAllDeliveryAddressesByUserId(securityUser.user().getId());
+        return ResponseEntity.ok(deliveryAddresses);
+    }
+
+    // 배송지 상세 조회
+
+    // 기본 배송지 조회
+}

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
@@ -1,0 +1,28 @@
+package com.lovecloud.ordermanagement.presentation.request;
+
+import com.lovecloud.ordermanagement.application.command.CreateDeliveryAddressCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateDeliveryAddressRequest(
+        @NotBlank
+        String deliveryName,
+        @NotBlank
+        String zipCode,
+        @NotBlank
+        String address,
+        @NotBlank
+        String detailAddress,
+        String deliveryMemo
+) {
+        public CreateDeliveryAddressCommand toCommand(Long userId) {
+                return CreateDeliveryAddressCommand.builder()
+                        .userId(userId)
+                        .deliveryName(deliveryName())
+                        .zipCode(zipCode())
+                        .address(address())
+                        .detailAddress(detailAddress())
+                        .deliveryMemo(deliveryMemo())
+                        .build();
+        }
+
+}

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
@@ -12,7 +12,14 @@ public record CreateDeliveryAddressRequest(
         String address,
         @NotBlank
         String detailAddress,
-        String deliveryMemo
+        String deliveryMemo,
+        @NotBlank
+        String receiverName,
+        @NotBlank
+        String receiverPhoneNumber,
+        @NotBlank
+        boolean isDefault
+
 ) {
         public CreateDeliveryAddressCommand toCommand(Long userId) {
                 return CreateDeliveryAddressCommand.builder()
@@ -22,6 +29,9 @@ public record CreateDeliveryAddressRequest(
                         .address(address())
                         .detailAddress(detailAddress())
                         .deliveryMemo(deliveryMemo())
+                        .receiverName(receiverName())
+                        .receiverPhoneNumber(receiverPhoneNumber())
+                        .isDefault(isDefault())
                         .build();
         }
 

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/CreateDeliveryAddressRequest.java
@@ -2,6 +2,8 @@ package com.lovecloud.ordermanagement.presentation.request;
 
 import com.lovecloud.ordermanagement.application.command.CreateDeliveryAddressCommand;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record CreateDeliveryAddressRequest(
         @NotBlank
@@ -17,8 +19,8 @@ public record CreateDeliveryAddressRequest(
         String receiverName,
         @NotBlank
         String receiverPhoneNumber,
-        @NotBlank
-        boolean isDefault
+        @NotNull
+        Boolean isDefault
 
 ) {
         public CreateDeliveryAddressCommand toCommand(Long userId) {

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
@@ -4,15 +4,29 @@ import com.lovecloud.ordermanagement.application.command.UpdateDeliveryAddressCo
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateDeliveryAddressRequest(
-        @NotBlank String deliveryName,
+        @NotBlank
+        String deliveryName,
 
-        @NotBlank String zipCode,
+        @NotBlank
+        String zipCode,
 
-        @NotBlank String address,
+        @NotBlank
+        String address,
 
-        @NotBlank String detailAddress,
+        @NotBlank
+        String detailAddress,
 
-        String deliveryMemo) {
+        String deliveryMemo,
+
+        @NotBlank
+        String receiverName,
+
+        @NotBlank
+        String receiverPhoneNumber,
+
+        @NotBlank
+        boolean isDefault
+) {
     public UpdateDeliveryAddressCommand toCommand(Long userId, Long deliveryAddressId) {
         return UpdateDeliveryAddressCommand.builder()
                 .userId(userId)
@@ -22,6 +36,9 @@ public record UpdateDeliveryAddressRequest(
                 .address(address())
                 .detailAddress(detailAddress())
                 .deliveryMemo(deliveryMemo())
+                .receiverName(receiverName())
+                .receiverPhoneNumber(receiverPhoneNumber())
+                .isDefault(isDefault())
                 .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
@@ -2,6 +2,8 @@ package com.lovecloud.ordermanagement.presentation.request;
 
 import com.lovecloud.ordermanagement.application.command.UpdateDeliveryAddressCommand;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record UpdateDeliveryAddressRequest(
         @NotBlank
@@ -24,8 +26,8 @@ public record UpdateDeliveryAddressRequest(
         @NotBlank
         String receiverPhoneNumber,
 
-        @NotBlank
-        boolean isDefault
+        @NotNull
+        Boolean isDefault
 ) {
     public UpdateDeliveryAddressCommand toCommand(Long userId, Long deliveryAddressId) {
         return UpdateDeliveryAddressCommand.builder()

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/request/UpdateDeliveryAddressRequest.java
@@ -1,0 +1,27 @@
+package com.lovecloud.ordermanagement.presentation.request;
+
+import com.lovecloud.ordermanagement.application.command.UpdateDeliveryAddressCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateDeliveryAddressRequest(
+        @NotBlank String deliveryName,
+
+        @NotBlank String zipCode,
+
+        @NotBlank String address,
+
+        @NotBlank String detailAddress,
+
+        String deliveryMemo) {
+    public UpdateDeliveryAddressCommand toCommand(Long userId, Long deliveryAddressId) {
+        return UpdateDeliveryAddressCommand.builder()
+                .userId(userId)
+                .deliveryAddressId(deliveryAddressId)
+                .deliveryName(deliveryName())
+                .zipCode(zipCode())
+                .address(address())
+                .detailAddress(detailAddress())
+                .deliveryMemo(deliveryMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/query/response/DeliveryAddressResponse.java
+++ b/src/main/java/com/lovecloud/ordermanagement/query/response/DeliveryAddressResponse.java
@@ -1,0 +1,29 @@
+package com.lovecloud.ordermanagement.query.response;
+
+import com.lovecloud.ordermanagement.domain.DeliveryAddress;
+
+public record DeliveryAddressResponse(
+        Long id,
+        String deliveryName,
+        String zipCode,
+        String address,
+        String detailAddress,
+        String deliveryMemo,
+        String receiverName,
+        String receiverPhoneNumber,
+        boolean isDefault
+) {
+    public static DeliveryAddressResponse from(DeliveryAddress deliveryAddress) {
+        return new DeliveryAddressResponse(
+                deliveryAddress.getId(),
+                deliveryAddress.getDeliveryName(),
+                deliveryAddress.getZipCode(),
+                deliveryAddress.getAddress(),
+                deliveryAddress.getDetailAddress(),
+                deliveryAddress.getDeliveryMemo(),
+                deliveryAddress.getReceiverName(),
+                deliveryAddress.getReceiverPhoneNumber(),
+                deliveryAddress.isDefault()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,9 +18,9 @@ spring:
       max-request-size: 50MB
   redis:
     data:
-      host:  ${SPRING_REDIS_HOST}
-      port: ${SPRING_REDIS_PORT}
-      password: ${SPRING_REDIS_PASSWORD}
+      host:  ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
closed #68 

## 💗 작업 동기
배송지 등록,조회,수정,삭제 기능과 기본배송지 설정 기능, 배송지 목록 조회 및 단일 조회 기능이 필요하다.

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 배송지 등록 기능 구현
- [x] 배송지 수정 기능 구현
- [x] 배송지 삭제 기능 구현
- [x] 배송지 목록 조회 기능 구현
- [x] 배송지 단일 조회 기능 구현
- [x] 기본배송지 설정 기능 구현
- [x] 기본배송지 조회 기능 구현

## 🎯 리뷰 포인트
기본배송지 설정 기능을 위해 DeliveryAddress엔티티에 isDefault 필드를 추가했습니다.

하나의 배송지만 기본배송지가 될 수 있도록 하기 위해
기본배송지 설정시에 사용자의 모든 배송지를 기본배송지가 아니도록 설정한 후 기본배송지를 지정하도록 했습니다.

(기본배송지 설정은 배송지 생성 및 수정시에도 설정 가능합니다)


## ✅ 테스트 결과

1. 배송지 등록
![image](https://github.com/user-attachments/assets/fbec7511-83af-4678-a264-5e8b5362c28c)

2. 배송지 수정
![image](https://github.com/user-attachments/assets/0f63524d-b4bf-4e75-939b-6b577d044c0f)

3. 배송지 삭제
![image](https://github.com/user-attachments/assets/61599266-12ca-46a6-85b9-17a361473911)

4. 배송지 목록 조회
<img width="994" alt="스크린샷 2024-09-13 오후 9 23 45" src="https://github.com/user-attachments/assets/3986c043-a008-4d0d-8a57-38dcba375336">

5. 배송지 조회
![image](https://github.com/user-attachments/assets/f38c8ab8-1c5a-416a-899e-3592a0f01a5e)

6. 기본배송지 설정
![image](https://github.com/user-attachments/assets/74d14a14-869b-44e3-9db2-86d02813a3fd)

7. 기본배송지 조회
![image](https://github.com/user-attachments/assets/f14a2c64-ac95-4c89-b7c2-cfa05d1009f8)
 