### PR TITLE
Feat/#151 하객 및 부부 생성 시 지갑 생성 후 할당

### DIFF
--- a/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
+++ b/src/main/java/com/lovecloud/auth/application/GuestAuthService.java
@@ -5,6 +5,8 @@ import com.lovecloud.auth.domain.GuestRepository;
 import com.lovecloud.auth.domain.GuestValidator;
 import com.lovecloud.auth.domain.Password;
 import com.lovecloud.auth.presentation.request.GuestSignInRequest;
+import com.lovecloud.blockchain.application.WalletCreationService;
+import com.lovecloud.blockchain.domain.Wallet;
 import com.lovecloud.global.crypto.CustomPasswordEncoder;
 import com.lovecloud.global.jwt.JwtTokenProvider;
 import com.lovecloud.global.jwt.dto.JwtTokenDto;
@@ -23,6 +25,7 @@ public class GuestAuthService {
     private final CustomPasswordEncoder passwordEncoder;
     private final RefreshTokenServiceImpl refreshTokenService;
     private final AuthService authService;
+    private final WalletCreationService walletCreationService;
 
     /**
      * GuestSignupCommand를 기반으로 회원을 생성하고, 토큰을 발급하는 메서드
@@ -37,6 +40,11 @@ public class GuestAuthService {
         Password password = passwordEncoder.encode(command.password());
         Guest user = command.toGuest(password);
         user.signUp(validator);
+
+        guestRepository.save(user);
+
+        Wallet wallet = walletCreationService.saveWallet();
+        user.assignWallet(wallet);
 
         guestRepository.save(user);
 

--- a/src/main/java/com/lovecloud/usermanagement/application/CoupleCreationService.java
+++ b/src/main/java/com/lovecloud/usermanagement/application/CoupleCreationService.java
@@ -2,6 +2,8 @@ package com.lovecloud.usermanagement.application;
 
 import com.lovecloud.auth.domain.WeddingUserRepository;
 import com.lovecloud.auth.domain.WeddingUserValidator;
+import com.lovecloud.blockchain.application.WalletCreationService;
+import com.lovecloud.blockchain.domain.Wallet;
 import com.lovecloud.usermanagement.domain.Couple;
 import com.lovecloud.usermanagement.domain.WeddingRole;
 import com.lovecloud.usermanagement.domain.WeddingUser;
@@ -18,6 +20,7 @@ public class CoupleCreationService {
     private final WeddingUserRepository weddingUserRepository;
     private final WeddingUserValidator weddingUserValidator;
     private final CoupleRepository coupleRepository;
+    private final WalletCreationService walletCreationService;
 
     public void createCouple(WeddingUser newUser, String invitationCode) {
 
@@ -31,6 +34,11 @@ public class CoupleCreationService {
                 .groom(newUser.getWeddingRole() == WeddingRole.GROOM ? newUser : existingUser)
                 .bride(newUser.getWeddingRole() == WeddingRole.BRIDE ? newUser : existingUser)
                 .build();
+
+        coupleRepository.save(couple);
+
+        Wallet wallet = walletCreationService.saveWallet();
+        couple.assignWallet(wallet);
 
         coupleRepository.save(couple);
     }

--- a/src/main/java/com/lovecloud/usermanagement/domain/Couple.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Couple.java
@@ -47,7 +47,7 @@ public class Couple extends CommonRootEntity<Long> {
     private Invitation invitation;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "wallet_id", nullable = false)
+    @JoinColumn(name = "wallet_id")
     private Wallet wallet;
 
     @Builder

--- a/src/main/java/com/lovecloud/usermanagement/domain/Couple.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Couple.java
@@ -63,4 +63,11 @@ public class Couple extends CommonRootEntity<Long> {
     public void setInvitation(Invitation invitation) {
         this.invitation = invitation;
     }
+
+    public void assignWallet(Wallet wallet) {
+        if(this.wallet != null){ //TODO: 예외 추가
+            throw new IllegalStateException("이미 지갑이 할당되어 있습니다.");
+        }
+        this.wallet = wallet;
+    }
 }

--- a/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class Guest extends User {
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "wallet_id", nullable = false)
+    @JoinColumn(name = "wallet_id")
     private Wallet wallet;
 
     @Column(name = "phone_number", nullable = false, length = 100)
@@ -44,5 +44,12 @@ public class Guest extends User {
 
     public void signIn(String rawPassword, CustomPasswordEncoder passwordEncoder){
         this.password.validatePassword(rawPassword, passwordEncoder);
+    }
+
+    public void assignWallet(Wallet wallet){
+        if(this.wallet != null){
+            throw new IllegalStateException("이미 지갑이 할당되어 있습니다.");
+        }
+        this.wallet = wallet;
     }
 }

--- a/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
+++ b/src/main/java/com/lovecloud/usermanagement/domain/Guest.java
@@ -47,7 +47,7 @@ public class Guest extends User {
     }
 
     public void assignWallet(Wallet wallet){
-        if(this.wallet != null){
+        if(this.wallet != null){ //TODO: 예외 추가
             throw new IllegalStateException("이미 지갑이 할당되어 있습니다.");
         }
         this.wallet = wallet;


### PR DESCRIPTION
## 📌 관련 이슈
closed #151 

## 💗 작업 동기
지갑 생성 및 할당 로직 검토 요청

## 🛠️ 작업 내용
- [x] guest, couple 엔티티의 wallet 필드 non-nullable로 변경
- [x] assignWallet 메서드 생성 후 각각 guestAuthService, coupleCreationService에 해당 로직 구현

## 🎯 리뷰 포인트

- 아래 읽어보시고 맘에 안드시거나 의견 있으시면 적극 반영하겠습니다.

- 지갑 생성 로직
1. Guest 및 Couple 엔티티를 생성한 후 DB에 먼저 저장
2. 지갑 객체를 별도로 생성
3. assignWallet 메소드를 통해 이미 저장된 Guest 및 Couple 엔티티에 지갑을 할당
4. 지갑이 추가된 엔티티를 다시 DB에 저장

- 이렇게 한 이유
1. 지갑 생성은 복잡한 로직이 포함되어 있어 오류가 발생할 가능성이 있다. 따라서 지갑을 생성하기 전에 미리 guest, couple을 DB에 저장해두자.
2. 코드 가독성 (지갑 생성 로직이 따로 있는게 이해하기 쉬울것 같다)

- 우려한 점
1. DB에 2번 저장한다. 
2. 지갑이 없는 엔티티가 생긴다.


## ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/ac533929-6fc5-4c0f-8d3a-e71572bfb60e)
