### PR TITLE
Feat/#155 wallet 생성 시 관리자 계정에서 wallet으로 ether 보내는 기능 추가

### DIFF
--- a/src/main/java/com/lovecloud/blockchain/application/EtherTransferService.java
+++ b/src/main/java/com/lovecloud/blockchain/application/EtherTransferService.java
@@ -1,0 +1,49 @@
+package com.lovecloud.blockchain.application;
+
+import com.lovecloud.blockchain.exception.FailTransferEtherException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.utils.Convert;
+import org.web3j.utils.Numeric;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Service
+@RequiredArgsConstructor
+public class EtherTransferService {
+
+    @Value("${web3j.chain-id}")
+    private int chainId;
+
+    private final Web3j web3j;
+    private final Credentials adminCredentials;
+
+    public String transferEther(String toAddress) {
+
+        try {
+            BigInteger nonce = web3j.ethGetTransactionCount(adminCredentials.getAddress(), DefaultBlockParameterName.LATEST).send().getTransactionCount();
+            BigInteger gasPrice = BigInteger.valueOf(1000000000L);
+            BigInteger gasLimit = BigInteger.valueOf(300000L);
+            BigInteger value = Convert.toWei(BigDecimal.valueOf(0.1), Convert.Unit.ETHER).toBigInteger();
+
+            RawTransaction rawTransaction = RawTransaction.createEtherTransaction(nonce, gasPrice, gasLimit, toAddress, value);
+
+            byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, chainId, adminCredentials);
+            String hexValue = Numeric.toHexString(signedMessage);
+
+            EthSendTransaction ethSendTransaction = web3j.ethSendRawTransaction(hexValue).send();
+
+            return ethSendTransaction.getTransactionHash();
+        } catch (Exception e) {
+            throw new FailTransferEtherException();
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/blockchain/application/EtherTransferService.java
+++ b/src/main/java/com/lovecloud/blockchain/application/EtherTransferService.java
@@ -30,9 +30,9 @@ public class EtherTransferService {
 
         try {
             BigInteger nonce = web3j.ethGetTransactionCount(adminCredentials.getAddress(), DefaultBlockParameterName.LATEST).send().getTransactionCount();
-            BigInteger gasPrice = BigInteger.valueOf(1000000000L);
+            BigInteger gasPrice = BigInteger.valueOf(1000000000L); //TODO: gasPrice, gasLimit, value 설정 추후 협의 필
             BigInteger gasLimit = BigInteger.valueOf(300000L);
-            BigInteger value = Convert.toWei(BigDecimal.valueOf(0.1), Convert.Unit.ETHER).toBigInteger();
+            BigInteger value = Convert.toWei(BigDecimal.valueOf(0.01), Convert.Unit.ETHER).toBigInteger();
 
             RawTransaction rawTransaction = RawTransaction.createEtherTransaction(nonce, gasPrice, gasLimit, toAddress, value);
 

--- a/src/main/java/com/lovecloud/blockchain/application/WalletCreationService.java
+++ b/src/main/java/com/lovecloud/blockchain/application/WalletCreationService.java
@@ -21,8 +21,8 @@ public class WalletCreationService {
     private final String keyFilePassword = "${web3j.keyfile-password}"; //사용자 마다 달라야 하지만 일단 시스템에서 통일
     private final WalletRepository walletRepository;
     private final WalletVerifyService walletVerifyService;
+    private final EtherTransferService etherTransferService;
 
-    private Wallet wallet;
 
     /**
      * 지갑 생성 함수
@@ -66,6 +66,7 @@ public class WalletCreationService {
 
         String keyfile = createWallet();
         Credentials account = walletVerifyService.verifyWallet(keyfile); //지갑의 Credentials 객체 (비밀 키, 공개 키, 주소 등의 정보를 포함)
+        String transactionReceipt = etherTransferService.transferEther(account.getAddress()); //지갑 주소로 이더 전송 (테스트용, 실제로는 필요 없음
 
         return walletRepository.save(Wallet.builder()
                 .address(account.getAddress())

--- a/src/main/java/com/lovecloud/blockchain/exception/FailTransferEtherException.java
+++ b/src/main/java/com/lovecloud/blockchain/exception/FailTransferEtherException.java
@@ -1,0 +1,13 @@
+package com.lovecloud.blockchain.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+public class FailTransferEtherException extends LoveCloudException {
+
+    public FailTransferEtherException() {
+        super(new ErrorCode(INTERNAL_SERVER_ERROR, "이더 전송에 실패했습니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/global/config/Web3jConfig.java
+++ b/src/main/java/com/lovecloud/global/config/Web3jConfig.java
@@ -2,8 +2,13 @@ package com.lovecloud.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.crypto.exception.CipherException;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.http.HttpService;
+
+import java.io.IOException;
 
 @Configuration
 public class Web3jConfig {
@@ -11,5 +16,10 @@ public class Web3jConfig {
     @Bean
     public Web3j web3j() {
         return Web3j.build(new HttpService("${web3j.private-network}"));
+    }
+
+    @Bean
+    public Credentials adminCredentials() throws IOException, CipherException {
+        return WalletUtils.loadCredentials("${web3j.admin-wallet-password}", "${web3j.admin-keyfile-path}");
     }
 }

--- a/src/main/java/com/lovecloud/global/config/Web3jConfig.java
+++ b/src/main/java/com/lovecloud/global/config/Web3jConfig.java
@@ -1,5 +1,6 @@
 package com.lovecloud.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.web3j.crypto.Credentials;
@@ -13,13 +14,22 @@ import java.io.IOException;
 @Configuration
 public class Web3jConfig {
 
+    @Value("${web3j.private-network}")
+    private String privateNetwork;
+
+    @Value("${web3j.admin-wallet-password}")
+    private String adminWalletPassword;
+
+    @Value("${web3j.admin-keyfile-path}")
+    private String adminKeyfilePath;
+
     @Bean
     public Web3j web3j() {
-        return Web3j.build(new HttpService("${web3j.private-network}"));
+        return Web3j.build(new HttpService(privateNetwork));
     }
 
     @Bean
     public Credentials adminCredentials() throws IOException, CipherException {
-        return WalletUtils.loadCredentials("${web3j.admin-wallet-password}", "${web3j.admin-keyfile-path}");
+        return WalletUtils.loadCredentials(adminWalletPassword, adminKeyfilePath);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,6 @@ jwt:
 web3j:
   private-network: ${WEB3J_PRIVATE_NETWORK}
   keyfile-password: ${WEB3J_KEYFILE_PASSWORD}
+  admin-keyfile-path: ${WEB3J_ADMIN_KEYFILE_PATH}
+  admin-wallet-password: ${WEB3J_ADMIN_WALLET_PASSWORD}
+  chain-id: ${WEB3J_CHAIN_ID}


### PR DESCRIPTION
## 📌 관련 이슈
closed #155 

## 💗 작업 동기
guest 생성 시 관리자 계정에서 생성된 wallet으로 ether 전송하는 기능 추가

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] adminCredentials 관리자 계정 빈 등록
- [x] FailTransferEtherException 추가
- [x] EtherTransferService에 transferEther 함수 구현

## 🎯 리뷰 포인트
- 환경변수 추가해주세요
1. adminWalletPassword : 저희 관리자 지갑 비밀번호
2. adminKeyfilePath : 본인 로컬 keystore 파일에 있는 관리자 keyfile 경로 (UTC--  형태)

- 관리자 계정 정보를 담은 객체 adminCredentials를 Web3jConfig에서 빈으로 등록하였습니다. (서명을 하기 위해)

- 하객 계정 생성 시 실행되는 saveWallet() 함수 안에서 transferEther()를 실행하도록 하였습니다.

- gasPrice, gasLimit, value 설정 필요
현재 gasPrice=1GWei, gasLimit=30,000, value=0.01ETH 로 설정해놨지만 논의하여 변경해야 합니다.

## ✅ 테스트 결과

- 생성된 지갑에 0.01ETH 전송
![image](https://github.com/user-attachments/assets/dbe5d135-3f40-47d1-86a9-556036b9c84d)

- 트랜잭션 성공
![image](https://github.com/user-attachments/assets/4adaa240-7086-4291-9c66-5b2bdf6af982)
