### PR TITLE
feat: QueryDSL 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -48,7 +54,6 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
 
-
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
@@ -57,6 +62,14 @@ dependencies {
 
     implementation 'org.web3j:core:4.12.1'
 
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', 'build/generated/sources/annotationProcessor/java/main']
+        }
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lovecloud/global/config/QueryDslConfig.java
+++ b/src/main/java/com/lovecloud/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.lovecloud.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #171

## 💗 작업 동기
복잡한 쿼리의 효율적인 작성을 위해 QueryDSL을 도입하고자 합니다. 타입 안전하고 가독성 높은 쿼리를 작성할 수 있으며, 쿼리의 중복 또한 줄어듭니다.

## 🛠️ 작업 내용
- [x] QueryDSL 의존성 추가
- [x] QueryDSL 설정 작성

## 🎯 리뷰 포인트

./gradlew clean compileJava 실행하면 build/generated 하위에 Q 객체 생성됩니다.

## ✅ 테스트 결과