### PR TITLE
Feat: 주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/lovecloud/blockchain/exception/SmartContractFundingNotCompletedException.java
+++ b/src/main/java/com/lovecloud/blockchain/exception/SmartContractFundingNotCompletedException.java
@@ -1,0 +1,12 @@
+package com.lovecloud.blockchain.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+import org.springframework.http.HttpStatus;
+
+public class SmartContractFundingNotCompletedException extends LoveCloudException {
+    public SmartContractFundingNotCompletedException() {
+        super(new ErrorCode(HttpStatus.BAD_REQUEST, "스마트 컨트랙트 펀딩이 완료되지 않았습니다."));
+    }
+
+}

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
@@ -1,5 +1,6 @@
 package com.lovecloud.ordermanagement.application;
 
+import com.lovecloud.blockchain.application.WeddingCrowdFundingService;
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.FundingStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
@@ -36,6 +37,7 @@ public class OrderCreateService {
     private final OrderDetailsRepository orderDetailsRepository;
     private final DeliveryRepository deliveryRepository;
     private final ProductOptionsRepository productOptionsRepository;
+    private final WeddingCrowdFundingService weddingCrowdFundingService;
 
     public Long createOrder(CreateOrderCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
@@ -56,7 +58,11 @@ public class OrderCreateService {
         fundings.forEach(funding ->
                 productOptionsRepository.findByIdWithLockOrThrow(funding.getProductOptions().getId()).decreaseStockQuantity());
 
-        //TODO: 블록체인 연동
+        /**
+         * TODO: 블록체인 연동
+         * fundingBlockchainId가 정의되어야 함
+         * */
+        //fundings.forEach(funding -> weddingCrowdFundingService.completeOrder(couple.getWallet().getKeyfile(), fundingBlockchainId) );
 
         return order.getId();
     }

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
@@ -41,18 +41,6 @@ public class OrderCreateService {
     private final ProductOptionsRepository productOptionsRepository;
     private final WeddingCrowdFundingService weddingCrowdFundingService;
 
-    private static Delivery createDelivery(CreateOrderCommand command) {
-        return Delivery.builder()
-                .deliveryName(command.deliveryName())
-                .receiverName(command.receiverName())
-                .receiverPhoneNumber(command.receiverPhoneNumber())
-                .zipCode(command.zipCode())
-                .address(command.address())
-                .detailAddress(command.detailAddress())
-                .deliveryMemo(command.deliveryMemo())
-                .build();
-    }
-
     public Long createOrder(CreateOrderCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
         List<Funding> fundings = fundingRepository.findAllById(command.fundingIds());
@@ -139,5 +127,17 @@ public class OrderCreateService {
         if (!funding.getCouple().equals(couple)) {
             throw new MismatchedCoupleException();
         }
+    }
+
+    private static Delivery createDelivery(CreateOrderCommand command) {
+        return Delivery.builder()
+                .deliveryName(command.deliveryName())
+                .receiverName(command.receiverName())
+                .receiverPhoneNumber(command.receiverPhoneNumber())
+                .zipCode(command.zipCode())
+                .address(command.address())
+                .detailAddress(command.detailAddress())
+                .deliveryMemo(command.deliveryMemo())
+                .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
@@ -1,13 +1,14 @@
 package com.lovecloud.ordermanagement.application;
 
+import com.lovecloud.blockchain.application.WalletPathResolver;
 import com.lovecloud.blockchain.application.WeddingCrowdFundingService;
+import com.lovecloud.blockchain.exception.FundingBlockchainException;
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.FundingStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
 import com.lovecloud.global.util.DateUuidGenerator;
 import com.lovecloud.ordermanagement.application.command.CreateOrderCommand;
 import com.lovecloud.ordermanagement.domain.Delivery;
-import com.lovecloud.ordermanagement.domain.DeliveryStatus;
 import com.lovecloud.ordermanagement.domain.Order;
 import com.lovecloud.ordermanagement.domain.OrderDetails;
 import com.lovecloud.ordermanagement.domain.repository.DeliveryRepository;
@@ -21,12 +22,13 @@ import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepositor
 import com.lovecloud.usermanagement.domain.Couple;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -38,6 +40,18 @@ public class OrderCreateService {
     private final DeliveryRepository deliveryRepository;
     private final ProductOptionsRepository productOptionsRepository;
     private final WeddingCrowdFundingService weddingCrowdFundingService;
+
+    private static Delivery createDelivery(CreateOrderCommand command) {
+        return Delivery.builder()
+                .deliveryName(command.deliveryName())
+                .receiverName(command.receiverName())
+                .receiverPhoneNumber(command.receiverPhoneNumber())
+                .zipCode(command.zipCode())
+                .address(command.address())
+                .detailAddress(command.detailAddress())
+                .deliveryMemo(command.deliveryMemo())
+                .build();
+    }
 
     public Long createOrder(CreateOrderCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
@@ -62,8 +76,16 @@ public class OrderCreateService {
          * TODO: 블록체인 연동
          * fundingBlockchainId가 정의되어야 함
          * */
-        //fundings.forEach(funding -> weddingCrowdFundingService.completeOrder(couple.getWallet().getKeyfile(), fundingBlockchainId) );
-
+//        try {
+//            String walletFilePath = WalletPathResolver.resolveWalletPath(couple.getWallet().getKeyfile());
+//            // 블록체인 연동 - 주문 완료
+//            for (Funding funding : fundings) {
+//                String transactionHash = weddingCrowdFundingService.completeOrder(walletFilePath, funding.getBlockcainId());
+//                log.info("블록체인 트랜잭션 해시: {}", transactionHash);
+//            }
+//        } catch (Exception e) {
+//            throw new FundingBlockchainException("블록체인 연동 중 오류가 발생하였습니다.");
+//        }
         return order.getId();
     }
 
@@ -117,17 +139,5 @@ public class OrderCreateService {
         if (!funding.getCouple().equals(couple)) {
             throw new MismatchedCoupleException();
         }
-    }
-
-    private static Delivery createDelivery(CreateOrderCommand command) {
-        return Delivery.builder()
-                .deliveryName(command.deliveryName())
-                .receiverName(command.receiverName())
-                .receiverPhoneNumber(command.receiverPhoneNumber())
-                .zipCode(command.zipCode())
-                .address(command.address())
-                .detailAddress(command.detailAddress())
-                .deliveryMemo(command.deliveryMemo())
-                .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderCreateService.java
@@ -60,20 +60,17 @@ public class OrderCreateService {
         fundings.forEach(funding ->
                 productOptionsRepository.findByIdWithLockOrThrow(funding.getProductOptions().getId()).decreaseStockQuantity());
 
-        /**
-         * TODO: 블록체인 연동
-         * fundingBlockchainId가 정의되어야 함
-         * */
-//        try {
-//            String walletFilePath = WalletPathResolver.resolveWalletPath(couple.getWallet().getKeyfile());
-//            // 블록체인 연동 - 주문 완료
-//            for (Funding funding : fundings) {
-//                String transactionHash = weddingCrowdFundingService.completeOrder(walletFilePath, funding.getBlockcainId());
-//                log.info("블록체인 트랜잭션 해시: {}", transactionHash);
-//            }
-//        } catch (Exception e) {
-//            throw new FundingBlockchainException("블록체인 연동 중 오류가 발생하였습니다.");
-//        }
+        // 블록체인 연동 - 주문 완료
+        try {
+            String walletFilePath = WalletPathResolver.resolveWalletPath(couple.getWallet().getKeyfile());
+            // 블록체인 연동 - 주문 완료
+            for (Funding funding : fundings) {
+                String transactionHash = weddingCrowdFundingService.completeOrder(couple.getWallet().getKeyfile(), funding.getBlockchainFundingId());
+                log.info("블록체인 트랜잭션 해시: {}", transactionHash);
+            }
+        } catch (Exception e) {
+            throw new FundingBlockchainException("블록체인 연동 중 오류가 발생하였습니다.");
+        }
         return order.getId();
     }
 

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
@@ -1,10 +1,7 @@
 package com.lovecloud.ordermanagement.application;
 
-import com.lovecloud.blockchain.application.WalletPathResolver;
 import com.lovecloud.blockchain.application.WeddingCrowdFundingService;
-import com.lovecloud.blockchain.exception.FundingBlockchainException;
 import com.lovecloud.fundingmanagement.domain.Funding;
-import com.lovecloud.fundingmanagement.domain.FundingStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
 import com.lovecloud.global.util.DateUuidGenerator;
 import com.lovecloud.ordermanagement.application.command.CreateOrderCommand;
@@ -13,7 +10,6 @@ import com.lovecloud.ordermanagement.domain.*;
 import com.lovecloud.ordermanagement.domain.repository.DeliveryRepository;
 import com.lovecloud.ordermanagement.domain.repository.OrderDetailsRepository;
 import com.lovecloud.ordermanagement.domain.repository.OrderRepository;
-import com.lovecloud.ordermanagement.exception.*;
 import com.lovecloud.productmanagement.domain.repository.ProductOptionsRepository;
 import com.lovecloud.usermanagement.domain.Couple;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
@@ -24,11 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class OrderCreateService {
+public class OrderService {
     private final OrderRepository orderRepository;
     private final CoupleRepository coupleRepository;
     private final FundingRepository fundingRepository;
@@ -37,6 +34,18 @@ public class OrderCreateService {
     private final ProductOptionsRepository productOptionsRepository;
     private final OrderValidator orderValidator;
     private final WeddingCrowdFundingService weddingCrowdFundingService;
+
+    private static Delivery createDelivery(CreateOrderCommand command) {
+        return Delivery.builder()
+                .deliveryName(command.deliveryName())
+                .receiverName(command.receiverName())
+                .receiverPhoneNumber(command.receiverPhoneNumber())
+                .zipCode(command.zipCode())
+                .address(command.address())
+                .detailAddress(command.detailAddress())
+                .deliveryMemo(command.deliveryMemo())
+                .build();
+    }
 
     public Long createOrder(CreateOrderCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
@@ -122,22 +131,6 @@ public class OrderCreateService {
                 .ordererMemo(command.ordererMemo())
                 .orderDateTime(LocalDateTime.now())
                 .delivery(delivery)
-                .build();
-    }
-
-
-
-
-
-    private static Delivery createDelivery(CreateOrderCommand command) {
-        return Delivery.builder()
-                .deliveryName(command.deliveryName())
-                .receiverName(command.receiverName())
-                .receiverPhoneNumber(command.receiverPhoneNumber())
-                .zipCode(command.zipCode())
-                .address(command.address())
-                .detailAddress(command.detailAddress())
-                .deliveryMemo(command.deliveryMemo())
                 .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
@@ -35,18 +35,6 @@ public class OrderService {
     private final OrderValidator orderValidator;
     private final WeddingCrowdFundingService weddingCrowdFundingService;
 
-    private static Delivery createDelivery(CreateOrderCommand command) {
-        return Delivery.builder()
-                .deliveryName(command.deliveryName())
-                .receiverName(command.receiverName())
-                .receiverPhoneNumber(command.receiverPhoneNumber())
-                .zipCode(command.zipCode())
-                .address(command.address())
-                .detailAddress(command.detailAddress())
-                .deliveryMemo(command.deliveryMemo())
-                .build();
-    }
-
     public Long createOrder(CreateOrderCommand command) {
         Couple couple = coupleRepository.findByMemberIdOrThrow(command.userId());
         List<Funding> fundings = fundingRepository.findAllById(command.fundingIds());
@@ -133,6 +121,18 @@ public class OrderService {
                 .ordererMemo(command.ordererMemo())
                 .orderDateTime(LocalDateTime.now())
                 .delivery(delivery)
+                .build();
+    }
+
+    private static Delivery createDelivery(CreateOrderCommand command) {
+        return Delivery.builder()
+                .deliveryName(command.deliveryName())
+                .receiverName(command.receiverName())
+                .receiverPhoneNumber(command.receiverPhoneNumber())
+                .zipCode(command.zipCode())
+                .address(command.address())
+                .detailAddress(command.detailAddress())
+                .deliveryMemo(command.deliveryMemo())
                 .build();
     }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/OrderService.java
@@ -87,6 +87,8 @@ public class OrderService {
 //        } catch (Exception e) {
 //            throw new FundingBlockchainException("블록체인 연동 중 오류가 발생하였습니다.");
 //        }
+
+
         return order.getId();
     }
 

--- a/src/main/java/com/lovecloud/ordermanagement/application/validator/OrderValidator.java
+++ b/src/main/java/com/lovecloud/ordermanagement/application/validator/OrderValidator.java
@@ -1,0 +1,95 @@
+package com.lovecloud.ordermanagement.application.validator;
+
+import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.fundingmanagement.domain.FundingStatus;
+import com.lovecloud.ordermanagement.domain.DeliveryStatus;
+import com.lovecloud.ordermanagement.domain.Order;
+import com.lovecloud.ordermanagement.domain.OrderStatus;
+import com.lovecloud.ordermanagement.domain.repository.OrderDetailsRepository;
+import com.lovecloud.ordermanagement.exception.*;
+import com.lovecloud.usermanagement.domain.Couple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OrderValidator {
+
+    private final OrderDetailsRepository orderDetailsRepository;
+
+    /**
+     * (주문 생성시) 주문할 펀딩이 하나 이상 존재하는지 검증
+     * */
+    public void validateFundingsExistence(List<Funding> fundings) {
+        if (fundings.isEmpty()) {
+            throw new NoAvailableFundingsException();
+        }
+    }
+
+    /**
+     * (주문 생성시) 펀딩들에 대해 중복된 주문이 존재하는지 검증
+     * */
+    public void validateNoDuplicatedOrdersForFundings(List<Funding> fundings) {
+        List<Long> fundingIds = fundings.stream()
+                .map(Funding::getId)
+                .collect(Collectors.toList());
+
+        // 이미 주문된 펀딩 ID들을 조회
+        List<Long> duplicatedFundingIds = orderDetailsRepository.findDuplicatedFundingIds(fundingIds);
+        if (!duplicatedFundingIds.isEmpty()) {
+            throw new DuplicateOrderFundingException();
+        }
+    }
+
+    /**
+     * (주문 생성시) 펀딩들이 모두 완료된 상태인지 검증
+     * */
+    public void validateFundingsCompletion(List<Funding> fundings) {
+        boolean allCompleted = fundings.stream()
+                .allMatch(funding -> funding.getStatus().equals(FundingStatus.COMPLETED));
+        if (!allCompleted) {
+            throw new FundingNotCompletedException();
+        }
+    }
+
+    /**
+     * (주문 생성시) 주문자와 펀딩들의 소유자가 일치하는지 검증
+     * */
+    public void validateFundingsOwnership(List<Funding> fundings, Couple couple) {
+        boolean isOwner = fundings.stream()
+                .allMatch(funding -> funding.getCouple().equals(couple));
+        if (!isOwner) {
+            throw new MismatchedCoupleException();
+        }
+    }
+
+    /**
+     * 주문 소유자와 커플이 일치하는지 검증
+     */
+    public void validateOrderOwnership(Order order, Couple couple) {
+        if (!order.getCouple().getId().equals(couple.getId())) {
+            throw new UnauthorizedOrderAccessException();
+        }
+    }
+
+    /**
+     * (주문 취소시) 이미 취소된 주문인지 검증
+     */
+    public void validateOrderNotCancelled(Order order) {
+        if (order.getOrderStatus().equals(OrderStatus.CANCEL_REQUESTED) || order.getOrderStatus().equals(OrderStatus.CANCEL_COMPLETED)) {
+            throw new OrderAlreadyCancelledException();
+        }
+    }
+
+    /**
+     * (주문 취소시) 배송시작 전인지 검증
+     */
+    public void validateDeliveryNotStarted(Order order) {
+        if (!order.getDelivery().getDeliveryStatus().equals(DeliveryStatus.PENDING)) {
+            throw new DeliveryAlreadyStartedException();
+        }
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/domain/Order.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/Order.java
@@ -63,4 +63,8 @@ public class Order extends CommonRootEntity<Long> {
         this.couple = couple;
         this.delivery = delivery;
     }
+
+    public void cancel() {
+        this.orderStatus = OrderStatus.CANCEL_REQUESTED;
+    }
 }

--- a/src/main/java/com/lovecloud/ordermanagement/domain/OrderDetails.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/OrderDetails.java
@@ -2,16 +2,7 @@ package com.lovecloud.ordermanagement.domain;
 
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.global.domain.CommonRootEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +10,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "order_details")
+@Table(name = "order_details", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"funding_id", "order_id"}) // 복합 유니크 제약 설정
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderDetails extends CommonRootEntity<Long> {
 

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/OrderDetailsRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/OrderDetailsRepository.java
@@ -12,7 +12,7 @@ public interface OrderDetailsRepository extends JpaRepository<OrderDetails, Long
 
     List<OrderDetails> findAllByOrderId(Long id);
 
-    @Query("SELECT od.funding.id FROM OrderDetails od WHERE od.funding.id IN :fundingIds AND od.order.orderStatus != 'ORDER_PLACED'")
+    @Query("SELECT od.funding.id FROM OrderDetails od WHERE od.funding.id IN :fundingIds AND od.order.orderStatus = 'ORDER_PLACED'")
     List<Long> findDuplicatedFundingIds(@Param("fundingIds") List<Long> fundingIds);
 
 

--- a/src/main/java/com/lovecloud/ordermanagement/domain/repository/OrderDetailsRepository.java
+++ b/src/main/java/com/lovecloud/ordermanagement/domain/repository/OrderDetailsRepository.java
@@ -2,6 +2,8 @@ package com.lovecloud.ordermanagement.domain.repository;
 
 import com.lovecloud.ordermanagement.domain.OrderDetails;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,6 +12,8 @@ public interface OrderDetailsRepository extends JpaRepository<OrderDetails, Long
 
     List<OrderDetails> findAllByOrderId(Long id);
 
-    boolean existsByFundingId(Long id);
+    @Query("SELECT od.funding.id FROM OrderDetails od WHERE od.funding.id IN :fundingIds AND od.order.orderStatus != 'ORDER_PLACED'")
+    List<Long> findDuplicatedFundingIds(@Param("fundingIds") List<Long> fundingIds);
+
 
 }

--- a/src/main/java/com/lovecloud/ordermanagement/exception/DeliveryAlreadyStartedException.java
+++ b/src/main/java/com/lovecloud/ordermanagement/exception/DeliveryAlreadyStartedException.java
@@ -1,0 +1,11 @@
+package com.lovecloud.ordermanagement.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+import org.springframework.http.HttpStatus;
+
+public class DeliveryAlreadyStartedException extends LoveCloudException {
+    public DeliveryAlreadyStartedException() {
+        super(new ErrorCode(HttpStatus.BAD_REQUEST, "이미 배송이 시작된 주문입니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/exception/OrderAlreadyCancelledException.java
+++ b/src/main/java/com/lovecloud/ordermanagement/exception/OrderAlreadyCancelledException.java
@@ -1,0 +1,12 @@
+package com.lovecloud.ordermanagement.exception;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class OrderAlreadyCancelledException extends LoveCloudException {
+    public OrderAlreadyCancelledException(){
+        super(new ErrorCode(BAD_REQUEST,"이미 취소된 주문입니다."));
+    }
+}

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
@@ -1,7 +1,7 @@
 package com.lovecloud.ordermanagement.presentation;
 
 import com.lovecloud.global.usermanager.SecurityUser;
-import com.lovecloud.ordermanagement.application.OrderCreateService;
+import com.lovecloud.ordermanagement.application.OrderService;
 import com.lovecloud.ordermanagement.presentation.request.CreateOrderRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +17,14 @@ import java.net.URI;
 @RequestMapping("/orders")
 @RequiredArgsConstructor
 public class OrderController {
-    private final OrderCreateService orderCreateService;
+    private final OrderService orderService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     public ResponseEntity<Long> createOrder(@Valid @RequestBody CreateOrderRequest request,
                                             @AuthenticationPrincipal SecurityUser securityUser) {
-        final Long orderId = orderCreateService.createOrder(request.toCommand(securityUser.user().getId()));
+        final Long orderId = orderService.createOrder(request.toCommand(securityUser.user().getId()));
         return ResponseEntity.created(URI.create("/orders/" + orderId)).build();
     }
 
@@ -33,7 +33,7 @@ public class OrderController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
     public void cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal SecurityUser securityUser) {
-        orderCreateService.cancelOrder(orderId, securityUser.user().getId());
+        orderService.cancelOrder(orderId, securityUser.user().getId());
     }
 
 }

--- a/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
+++ b/src/main/java/com/lovecloud/ordermanagement/presentation/OrderController.java
@@ -27,4 +27,13 @@ public class OrderController {
         final Long orderId = orderCreateService.createOrder(request.toCommand(securityUser.user().getId()));
         return ResponseEntity.created(URI.create("/orders/" + orderId)).build();
     }
+
+    //주문 취소
+    @PatchMapping("/{orderId}/cancel")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    public void cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal SecurityUser securityUser) {
+        orderCreateService.cancelOrder(orderId, securityUser.user().getId());
+    }
+
 }

--- a/src/main/java/com/lovecloud/ordermanagement/query/response/OrderDetailResponse.java
+++ b/src/main/java/com/lovecloud/ordermanagement/query/response/OrderDetailResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Builder
 public record OrderDetailResponse(
         Long orderId,
+        String orderStatus,
 
         String orderNumber,
 
@@ -39,6 +40,7 @@ public record OrderDetailResponse(
     public static OrderDetailResponse from(Order order) {
         return OrderDetailResponse.builder()
                 .orderId(order.getId())
+                .orderStatus(order.getOrderStatus().name())
                 .orderNumber(order.getOrderNumber())
                 .orderDateTime(order.getOrderDateTime())
                 .orderProducts(order.getOrderDetails().stream().map(orderDetail -> orderProduct.builder()

--- a/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
+++ b/src/main/java/com/lovecloud/productmanagement/domain/ProductOptions.java
@@ -84,4 +84,8 @@ public class ProductOptions extends CommonRootEntity<Long> {
         }
         stockQuantity--;
     }
+
+    public void increaseStockQuantity() {
+        stockQuantity++;
+    }
 }

--- a/src/test/java/com/lovecloud/ordermanagement/application/OrderServiceTest.java
+++ b/src/test/java/com/lovecloud/ordermanagement/application/OrderServiceTest.java
@@ -5,21 +5,13 @@ import com.lovecloud.auth.domain.WeddingUserRepository;
 import com.lovecloud.fundingmanagement.domain.Funding;
 import com.lovecloud.fundingmanagement.domain.FundingStatus;
 import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
-import com.lovecloud.invitationmanagement.application.InvitationCreateService;
-import com.lovecloud.invitationmanagement.application.command.CreateInvitationCommand;
-import com.lovecloud.invitationmanagement.domain.Invitation;
-import com.lovecloud.invitationmanagement.domain.InvitationImage;
-import com.lovecloud.invitationmanagement.domain.repository.InvitationImageRepository;
-import com.lovecloud.invitationmanagement.domain.repository.InvitationRepository;
 import com.lovecloud.ordermanagement.application.command.CreateOrderCommand;
 import com.lovecloud.ordermanagement.domain.Order;
 import com.lovecloud.ordermanagement.domain.OrderDetails;
 import com.lovecloud.ordermanagement.domain.repository.OrderDetailsRepository;
 import com.lovecloud.ordermanagement.domain.repository.OrderRepository;
-import com.lovecloud.ordermanagement.presentation.request.CreateOrderRequest;
 import com.lovecloud.productmanagement.domain.*;
 import com.lovecloud.productmanagement.domain.repository.*;
-import com.lovecloud.usermanagement.application.CoupleService;
 import com.lovecloud.usermanagement.domain.*;
 import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,9 +30,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-class OrderCreateServiceTest {
+class OrderServiceTest {
     @Autowired
-    private OrderCreateService orderCreateService;
+    private OrderService orderService;
 
     @Autowired
     private CoupleRepository coupleRepository;
@@ -213,7 +205,7 @@ class OrderCreateServiceTest {
 
 
             // when
-            Long orderId = orderCreateService.createOrder(command);
+            Long orderId = orderService.createOrder(command);
 
             // then
             Order order = orderRepository.findById(orderId).orElseThrow();


### PR DESCRIPTION
## 📌 관련 이슈
closed #164 

## 💗 작업 동기
주문 취소 기능 필요

## 🛠️ 작업 내용
- [x] 주문 취소 엔드포인트 구현
- [x] 주문 취소 로직 작성
- [x] 주문 검증 로직을 OrderValidator에서 처리하도록 코드 리팩터링
- [x] order_details 테이블에 복합제약조건 추가
- [x] 주문 생성시 검증 로직 수정 (기존: funding에 관한 order details가 존재하지 않는지 검증 / 수정후: funding에 관한 order details 중 order status가 order_placed인 것이 존재하지 않는지 검증)

## 🎯 리뷰 포인트
취소한 주문도 주문 상세 조회를 할 수 있어야되기 때문에 order_details테이블에 fundingId가 중복될 수 있어야합니다. 그래서 기존의 funding_id에 적용된 유니크 키 제약조건을 제거했고(mySQL에서 적용해제) 그 대신 order_id와 funding_id가 동시에 중복되지 않도록 복합제약조건을 추가했습니다. (@Table 어노테이션에 작성)

- 리뷰 포인트

## ✅ 테스트 결과
### 주문취소
![image](https://github.com/user-attachments/assets/92e2b7e5-81fa-4dda-931b-64f19ef78c86)

### 주문 취소 후 조회
![image](https://github.com/user-attachments/assets/62e92185-3a64-4fdd-b3f0-171096bd2a7c)

### 이미 취소된 주문을 취소할 때
![image](https://github.com/user-attachments/assets/6db23cf5-5a71-4efc-b2a6-3edf076309e1)

### 주문 취소 후 재주문
![image](https://github.com/user-attachments/assets/18eed4c8-3b37-4c56-a536-8ea8a5145231)

### 모든 주문 조회
<img width="1007" alt="스크린샷 2024-10-12 오후 7 14 32" src="https://github.com/user-attachments/assets/e2af21c2-8a0e-4641-aa6a-392c71ca4e1a">