### PR TITLE
feat: S3에 지갑 파일 업로드 기능 추가

### DIFF
--- a/src/main/java/com/lovecloud/infra/s3/AwsS3Property.java
+++ b/src/main/java/com/lovecloud/infra/s3/AwsS3Property.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AwsS3Property(
         String bucket,
         String imagePath,
+        String keyfilePath,
         int presignedUrlExpiresMinutes
 ) {
 }

--- a/src/main/java/com/lovecloud/infra/s3/KeyfileReadException.java
+++ b/src/main/java/com/lovecloud/infra/s3/KeyfileReadException.java
@@ -1,0 +1,13 @@
+package com.lovecloud.infra.s3;
+
+import com.lovecloud.global.exception.ErrorCode;
+import com.lovecloud.global.exception.LoveCloudException;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+public class KeyfileReadException extends LoveCloudException {
+
+    public KeyfileReadException(String path) {
+        super(new ErrorCode(INTERNAL_SERVER_ERROR, "Keyfile을 읽는 데 실패했습니다. 경로: " + path));
+    }
+}

--- a/src/main/java/com/lovecloud/infra/s3/KeyfileService.java
+++ b/src/main/java/com/lovecloud/infra/s3/KeyfileService.java
@@ -1,0 +1,68 @@
+package com.lovecloud.infra.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * AWS S3에 keyfile을 업로드하는 서비스 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class KeyfileService {
+
+    private final S3Client s3Client;
+    private final AwsS3Property s3Property;
+
+    /**
+     * 주어진 keyfile을 읽어 S3 버킷에 업로드합니다.
+     *
+     * @param keyfileName keyfile의 이름
+     * @param keyfilePath keyfile이 저장된 경로
+     */
+    public void uploadKeyfile(String keyfileName, String keyfilePath) {
+        Path path = Path.of(keyfilePath, keyfileName);
+
+        byte[] keyfileContent = readKeyfileContent(path);
+
+        uploadToS3(keyfileName, keyfileContent);
+    }
+
+    /**
+     * 주어진 경로에서 keyfile의 내용을 읽습니다.
+     *
+     * @param path keyfile의 경로
+     * @return keyfile의 내용 (byte 배열)
+     * @throws RuntimeException keyfile 읽기에 실패했을 때 발생
+     */
+    private byte[] readKeyfileContent(Path path) {
+        try {
+            return Files.readAllBytes(path);
+        } catch (IOException e) {
+            throw new KeyfileReadException(path.toString());
+        }
+    }
+
+    /**
+     * S3에 keyfile을 업로드합니다.
+     *
+     * @param keyfileName keyfile의 이름
+     * @param keyfileContent keyfile의 내용 (byte 배열)
+     */
+    private void uploadToS3(String keyfileName, byte[] keyfileContent) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3Property.bucket())
+                .key(s3Property.keyfilePath() + keyfileName)
+                .acl(ObjectCannedACL.PRIVATE)
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(keyfileContent));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ cloud:
     s3:
       bucket: ${AWS_BUCKET}
       image-path: "images/"
+      keyfile-path: "keyfiles/"
       presigned-url-expires-minutes: 10
     region:
       static: ${AWS_REGION}

--- a/src/test/java/com/lovecloud/infra/s3/KeyfileServiceIntegrationTest.java
+++ b/src/test/java/com/lovecloud/infra/s3/KeyfileServiceIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.lovecloud.infra.s3;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.web.SecurityFilterChain;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@EnableConfigurationProperties(AwsS3Property.class)
+class KeyfileServiceIntegrationTest {
+
+    @MockBean
+    private SecurityFilterChain securityFilterChain;
+
+    @Autowired
+    private KeyfileService keyfileService;
+
+    @Autowired
+    private AwsS3Property s3Property;
+
+    @Autowired
+    private S3Client s3Client;
+
+    private final String keyfileName = "test-keyfile-name";
+    private final String keyfileContent = "test-keyfile-content";
+    private final String keyfilePath = "./";
+
+    @Test
+    void testUploadKeyfileToS3() throws IOException {
+        // 로컬 테스트 파일 생성 (임시 파일 생성)
+        Path filePath = Path.of(keyfilePath, keyfileName);
+        Files.writeString(filePath, keyfileContent);
+
+        // 실제 S3 버킷에 업로드
+        keyfileService.uploadKeyfile(keyfileName, keyfilePath);
+
+        // 로컬 테스트 파일 삭제
+        Files.deleteIfExists(filePath);
+
+        // S3 버킷에 해당 파일이 존재하는지 확인
+        boolean isUploaded = checkIfFileExistsInS3(s3Property.keyfilePath() + keyfileName);
+        assertTrue(isUploaded, "S3 버킷에 파일이 정상적으로 업로드되지 않았습니다.");
+
+        // S3 버킷에 있는 파일의 내용이 예상한 내용과 일치하는지 확인
+        boolean isContentMatching = checkIfFileContentMatchesInS3(s3Property.keyfilePath() + keyfileName, keyfileContent);
+        assertTrue(isContentMatching, "S3에 저장된 파일 내용이 일치하지 않습니다.");
+    }
+
+    private boolean checkIfFileExistsInS3(String keyfileName) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(s3Property.bucket())
+                    .key(keyfileName)
+                    .build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    private boolean checkIfFileContentMatchesInS3(String keyfileName, String expectedContent) {
+        try {
+            // S3에서 파일을 다운로드
+            ResponseBytes<GetObjectResponse> s3Object = s3Client.getObjectAsBytes(GetObjectRequest.builder()
+                    .bucket(s3Property.bucket())
+                    .key(keyfileName)
+                    .build());
+
+            // S3에서 받은 파일의 내용을 문자열로 변환
+            String actualContent = s3Object.asUtf8String();
+
+            // 파일 내용이 예상한 값과 일치하는지 확인
+            return actualContent.equals(expectedContent);
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #170

## 💗 작업 동기
S3에 지갑 파일(keyfile)을 업로드하고 관리하기 위한 기능을 추가하게 되었습니다. AWS 버킷 정책도 변경하여 keyfile은 IAM 사용자만 PUT, GET할 수 있도록 하였습니다.

## 🛠️ 작업 내용
- [x] AWS S3 버킷 정책 수정
- [x] KeyfileService에서 로컬에서 S3로 지갑 파일을 업로드하는 기능 추가
- [x] S3에 업로드한 지갑 파일을 확인하고 내용 일치를 확인하는 통합 테스트 추가

## 🎯 리뷰 포인트

images 폴더는 모든 사용자에게 GetObject 및 PutObject 허용
keyfiles 폴더는 특정 IAM 사용자에게만 GetObject 및 PutObject 허용

## ✅ 테스트 결과

![image](https://github.com/user-attachments/assets/d815022f-a8c6-4ad3-bbd0-397d21e66593)
