### PR TITLE
feat: 본인이 참여한 펀딩 목록 및 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/lovecloud/auth/domain/WeddingUserRepository.java
+++ b/src/main/java/com/lovecloud/auth/domain/WeddingUserRepository.java
@@ -11,6 +11,10 @@ public interface WeddingUserRepository extends JpaRepository<WeddingUser, Long>{
 
     boolean existsByEmail(String email);
 
+    default WeddingUser findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(NotFoundUserException::new);
+    }
+
     default WeddingUser getByEmailOrThrow(String email) {
         return findByEmail(email)
                 .orElseThrow(NotFoundUserException::new);

--- a/src/main/java/com/lovecloud/blockchain/application/WeddingCrowdFundingService.java
+++ b/src/main/java/com/lovecloud/blockchain/application/WeddingCrowdFundingService.java
@@ -123,6 +123,27 @@ public class WeddingCrowdFundingService {
         }
     }
 
+    public String cancelCrowdFunding(BigInteger fundingId, String keyfileName) {
+        try {
+            // S3에서 지갑 파일을 가져옴
+            String keyfileContent = keyfileService.downloadKeyfile(keyfileName);
+            log.info("S3에서 지갑 파일 가져옴: {}", keyfileContent);
+
+            // 펀딩 스마트 컨트랙트 로드
+            WeddingCrowdFunding fundingContract = loadContract(keyfileContent);
+            log.info("스마트 컨트랙트 로드 완료.");
+
+            // 펀딩 트랜잭션 전송
+            TransactionReceipt receipt = fundingContract.cancelCrowdfunding(fundingId).send();
+            log.info("펀딩 취소 트랜잭션 해시: {}", receipt.getTransactionHash());
+
+            return receipt.getTransactionHash();
+        } catch (Exception e) {
+            log.error("블록체인 펀딩 참여 취소 중 에러 발생", e);
+            throw new BlockchainException("블록체인 펀딩 참여 취소 중 에러 발생", e);
+        }
+    }
+
     /**
      * 블록체인에 펀딩 기여를 처리하는 메서드
      *

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingCancellationService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingCancellationService.java
@@ -1,0 +1,55 @@
+package com.lovecloud.fundingmanagement.application;
+
+import com.lovecloud.auth.domain.WeddingUserRepository;
+import com.lovecloud.blockchain.application.WeddingCrowdFundingService;
+import com.lovecloud.blockchain.exception.FundingBlockchainException;
+import com.lovecloud.fundingmanagement.application.validator.FundingValidator;
+import com.lovecloud.fundingmanagement.domain.Funding;
+import com.lovecloud.fundingmanagement.domain.FundingStatus;
+import com.lovecloud.fundingmanagement.domain.repository.FundingRepository;
+import com.lovecloud.usermanagement.domain.Couple;
+import com.lovecloud.usermanagement.domain.WeddingUser;
+import com.lovecloud.usermanagement.domain.repository.CoupleRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class FundingCancellationService {
+
+    private final WeddingUserRepository weddingUserRepository;
+    private final FundingRepository fundingRepository;
+    private final FundingValidator fundingValidator;
+    private final CoupleRepository coupleRepository;
+    private final WeddingCrowdFundingService weddingCrowdFundingService;
+
+    public void cancelFunding(Long fundingId, Long userId) {
+        WeddingUser user = weddingUserRepository.findByIdOrThrow(userId);
+        Couple couple = coupleRepository.findByMemberIdOrThrow(userId);
+        Funding funding = fundingRepository.findByIdOrThrow(fundingId);
+
+        // 유효성 검사
+        fundingValidator.validateFundingOwnership(funding, couple);
+        fundingValidator.validateFundingStatus(funding, FundingStatus.IN_PROGRESS);
+
+        // 블록체인 연동 - 펀딩 취소
+        try {
+            String transactionHash = weddingCrowdFundingService.cancelCrowdFunding(
+                    funding.getBlockchainFundingId(),
+                    couple.getWallet().getKeyfile()
+            );
+
+            log.info("블록체인 트랜잭션 해시: {}", transactionHash);
+        } catch (Exception e) {
+            throw new FundingBlockchainException("블록체인 연동 중 오류가 발생하였습니다.");
+        }
+
+        // 펀딩 상태 변경
+        funding.cancel();
+        fundingRepository.save(funding);
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/application/FundingParticipationCancellationService.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/FundingParticipationCancellationService.java
@@ -64,7 +64,7 @@ public class FundingParticipationCancellationService {
 
         // GuestFunding 및 Funding 상태 업데이트
         guestFunding.updateStatus(ParticipationStatus.CANCELLED);
-        funding.decresaseCurrentAmount(guestFunding.getFundingAmount());
+        funding.decreaseCurrentAmount(guestFunding.getFundingAmount());
         guestFundingRepository.save(guestFunding);
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/application/validator/FundingValidator.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/application/validator/FundingValidator.java
@@ -12,6 +12,8 @@ import com.lovecloud.fundingmanagement.exception.MismatchedMerchantUidsException
 import com.lovecloud.payment.domain.Payment;
 import com.lovecloud.payment.domain.PaymentStatus;
 import com.lovecloud.payment.exception.InvalidPaymentStatusException;
+import com.lovecloud.usermanagement.domain.Couple;
+import com.lovecloud.usermanagement.domain.WeddingUser;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,6 +40,12 @@ public class FundingValidator {
     public void validateTargetAmountNotExceeded(Funding funding, Long amount) {
         if (funding.getCurrentAmount() + amount > funding.getTargetAmount()) {
             throw new FundingTargetExceededException();
+        }
+    }
+
+    public void validateFundingOwnership(Funding funding, Couple couple) {
+        if (!funding.getCouple().getId().equals(couple.getId())) {
+            throw new InvalidFundingStatusException();
         }
     }
 

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/Funding.java
@@ -1,6 +1,5 @@
 package com.lovecloud.fundingmanagement.domain;
 
-import com.lovecloud.blockchain.domain.Wallet;
 import com.lovecloud.global.domain.CommonRootEntity;
 import com.lovecloud.productmanagement.domain.ProductOptions;
 import com.lovecloud.usermanagement.domain.Couple;
@@ -65,6 +64,12 @@ public class Funding extends CommonRootEntity<Long> {
         this.couple = couple;
     }
 
+    public void cancel() {
+        if (this.status == FundingStatus.IN_PROGRESS) {
+            this.status = FundingStatus.CANCELED;
+        }
+    }
+
     public void increaseCurrentAmount(Long amount) {
         this.currentAmount += amount;
         if (this.currentAmount >= this.targetAmount && this.status == FundingStatus.IN_PROGRESS) {
@@ -73,7 +78,7 @@ public class Funding extends CommonRootEntity<Long> {
         }
     }
 
-    public void decresaseCurrentAmount(Long amount) {
+    public void decreaseCurrentAmount(Long amount) {
         if (amount <= this.currentAmount) {
             this.currentAmount -= amount;
         }

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/ParticipationDisplayStatus.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/ParticipationDisplayStatus.java
@@ -1,0 +1,42 @@
+package com.lovecloud.fundingmanagement.domain;
+
+import com.lovecloud.payment.domain.Payment;
+import com.lovecloud.payment.domain.PaymentStatus;
+
+public enum ParticipationDisplayStatus {
+    PENDING("결제 대기 중"),
+    COMPLETED("참여 완료"),
+    FAILED("참여 실패"),
+    CANCELLED("참여 취소"),
+    UNKNOWN("알 수 없음");
+
+    private final String message;
+
+    ParticipationDisplayStatus(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public static ParticipationDisplayStatus from(ParticipationStatus participationStatus, Payment payment) {
+        if (participationStatus == ParticipationStatus.PENDING
+                && (payment == null || payment.getPaymentStatus() == PaymentStatus.READY)) {
+            return PENDING;
+        }
+        if (participationStatus == ParticipationStatus.PAID
+                && payment != null && payment.getPaymentStatus() == PaymentStatus.PAID) {
+            return COMPLETED;
+        }
+        if (participationStatus == ParticipationStatus.FAILED
+                && payment != null && payment.getPaymentStatus() == PaymentStatus.FAILED) {
+            return FAILED;
+        }
+        if (participationStatus == ParticipationStatus.CANCELLED
+                && payment != null && payment.getPaymentStatus() == PaymentStatus.CANCELED) {
+            return CANCELLED;
+        }
+        return UNKNOWN;
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/domain/repository/GuestFundingRepository.java
@@ -41,4 +41,6 @@ public interface GuestFundingRepository extends JpaRepository<GuestFunding, Long
     boolean existsByGuestAndFundingWithStatuses(@Param("guest") Guest guest,
                                                 @Param("funding") Funding funding,
                                                 @Param("statuses") List<ParticipationStatus> statuses);
+
+    List<GuestFunding> findByGuestIdOrderByCreatedDateDesc(Long guestId);
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCancellationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingCancellationController.java
@@ -1,0 +1,29 @@
+package com.lovecloud.fundingmanagement.presentation;
+
+import com.lovecloud.fundingmanagement.application.FundingCancellationService;
+import com.lovecloud.global.usermanager.SecurityUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class FundingCancellationController {
+
+    private final FundingCancellationService fundingCancellationService;
+
+    @PreAuthorize("hasRole('ROLE_WEDDING_USER')")
+    @PatchMapping("/fundings/{fundingId}/cancel")
+    public ResponseEntity<Void> cancelFunding(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable Long fundingId
+    ) {
+        final Long userId = securityUser.user().getId();
+        fundingCancellationService.cancelFunding(fundingId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationCancellationController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingParticipationCancellationController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/presentation/FundingQueryController.java
@@ -5,6 +5,8 @@ import com.lovecloud.fundingmanagement.query.response.FundingDetailResponse;
 import com.lovecloud.fundingmanagement.query.response.FundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.GuestFundingListResponse;
 import com.lovecloud.fundingmanagement.query.response.OrderableFundingResponse;
+import com.lovecloud.fundingmanagement.query.response.ParticipatedFundingDetailResponse;
+import com.lovecloud.fundingmanagement.query.response.ParticipatedFundingListResponse;
 import com.lovecloud.global.usermanager.SecurityUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +54,29 @@ public class FundingQueryController {
             @AuthenticationPrincipal SecurityUser securityUser
     ) {
         final Long userId = securityUser.user().getId();
-        final List<OrderableFundingResponse> orderableFundings = fundingQueryService.findOrderableFundingsByUserId(userId);
+        final List<OrderableFundingResponse> orderableFundings = fundingQueryService.findOrderableFundingsByUserId(
+                userId);
         return ResponseEntity.ok(orderableFundings);
+    }
+
+    @PreAuthorize("hasRole('ROLE_GUEST')")
+    @GetMapping("/participations")
+    public ResponseEntity<List<ParticipatedFundingListResponse>> listParticipatedFundings(
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        final Long guestId = securityUser.user().getId();
+        final List<ParticipatedFundingListResponse> participations = fundingQueryService.findParticipations(guestId);
+        return ResponseEntity.ok(participations);
+    }
+
+    @PreAuthorize("hasRole('ROLE_GUEST')")
+    @GetMapping("/participations/{participationId}")
+    public ResponseEntity<ParticipatedFundingDetailResponse> detailParticipatedFunding(
+            @PathVariable Long participationId,
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        final Long guestId = securityUser.user().getId();
+        final ParticipatedFundingDetailResponse participation = fundingQueryService.findParticipation(guestId, participationId);
+        return ResponseEntity.ok(participation);
     }
 }

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/ParticipatedFundingDetailResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/ParticipatedFundingDetailResponse.java
@@ -1,0 +1,21 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.ParticipationDisplayStatus;
+import java.time.LocalDateTime;
+
+public record ParticipatedFundingDetailResponse(
+        Long guestFundingId,
+        String merchantUid,
+        String name,
+        String phoneNumber,
+        String email,
+        Long amount,
+        String message,
+        Long fundingId,
+        Long paymentId,
+        String impUid,
+        LocalDateTime paidAt,
+        String payMethod,
+        ParticipationDisplayStatus status
+) {
+}

--- a/src/main/java/com/lovecloud/fundingmanagement/query/response/ParticipatedFundingListResponse.java
+++ b/src/main/java/com/lovecloud/fundingmanagement/query/response/ParticipatedFundingListResponse.java
@@ -1,0 +1,21 @@
+package com.lovecloud.fundingmanagement.query.response;
+
+import com.lovecloud.fundingmanagement.domain.ParticipationDisplayStatus;
+import java.time.LocalDateTime;
+
+public record ParticipatedFundingListResponse(
+        Long guestFundingId,
+        String merchantUid,
+        String name,
+        String phoneNumber,
+        String email,
+        Long amount,
+        String message,
+        Long fundingId,
+        Long paymentId,
+        String impUid,
+        LocalDateTime paidAt,
+        String payMethod,
+        ParticipationDisplayStatus status
+) {
+}

--- a/src/main/java/com/lovecloud/global/config/SecurityConfig.java
+++ b/src/main/java/com/lovecloud/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
             "/fundings/**",
             "/payments/**",
             "/participations/**",
+            "/couples/**",
 
             "/wallet/**",
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #181

## 💗 작업 동기
하객이 본인이 참여한 펀딩 내역을 확인하고 상세 정보를 조회할 수 있는 기능 필요

## 🛠️ 작업 내용
- [x] [feat(SecurityConfig): 참여 관련 엔드포인트 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/4e745d3b057d24c76ac6e84643c21ae91d983e80)
- [x] [feat: 참여 목록 및 상세 조회 엔드포인트 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/ed5928815800cc16b6e3ef5e82c09d2b47181080)
- [x] [feat(ParticipatedFundingListResponse): 참여 목록 조회를 위한 레코드 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/b2053718433da40dbfb7600e24553a2965ce198d)
- [x] [feat(ParticipatedFundingDetailResponse): 참여한 펀딩 단건 응답을 위한 레코드 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/ec0f6257fe13357c759509e46df07312f6aaf316)
- [x] [feat: 참여 상태에 따른 표시 상태 관리 Enum 클래스 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/9bb2680edb276d19fbf419666b8bc2d999be2a62)
- [x] [feat(FundingQueryService): 게스트 펀딩 참여 상세 조회 및 목록 조회 로직 추가](https://github.com/yu-LoveCloud/love-cloud-was/commit/81ff77e90163a57b9abf200d5552bca79054c6a6)
- [x] [feat(GuestFundingRepository): 하객 ID로 게스트 펀딩을 조회하고 최신순으로 select](https://github.com/yu-LoveCloud/love-cloud-was/commit/a1ddb03a0e1fff794e6e2b9ea6fbb5be9dba5fef)

## 🎯 리뷰 포인트

하객이 참여한 펀딩의 상태를 ParticipationStatus와 Payment 조합을 통해 관리하도록 구현했습니다. 하객에게 보여줄 참여 상태입니다. 적절한지 살펴봐주세요.

- 결제 대기 중 (PENDING & READY, PENDING & null)
- 참여 완료 (PAID & PAID)
- 참여 실패 (FAILED & FAILED)
- 참여 취소 (CANCELLED & CANCELED)


## ✅ 테스트 결과

![image](https://github.com/user-attachments/assets/7e15e41d-56f7-4e8e-abaf-57b21233c2cf)

![image](https://github.com/user-attachments/assets/97fb227b-e335-4655-9624-61045ddc7a09)

